### PR TITLE
AGENT-502: Move App logic out of main

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -1,0 +1,24 @@
+package agent_tui
+
+import (
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/dialogs"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/forms"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+func App() {
+	app := tview.NewApplication()
+	pages := tview.NewPages()
+
+	background := tview.NewBox().
+		SetBorder(false).
+		SetBackgroundColor(newt.ColorBlue)
+
+	pages.AddPage("background", background, true, true).
+		AddPage("Node0", forms.IsNode0Modal(app, pages), true, true)
+
+	if err := app.SetRoot(pages, true).Run(); err != nil {
+		dialogs.PanicDialog(app, err)
+	}
+}

--- a/tools/agent_tui/dialogs/panic.go
+++ b/tools/agent_tui/dialogs/panic.go
@@ -1,4 +1,4 @@
-package agent_tui
+package dialogs
 
 import (
 	"github.com/rivo/tview"

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -1,56 +1,9 @@
 package main
 
 import (
-	"github.com/gdamore/tcell/v2"
-	"github.com/openshift/agent-installer-utils/tools/agent_tui/forms"
-	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
-	"github.com/rivo/tview"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui"
 )
-
-const (
-	QUIT      string = "Quit"
-	CONFIGURE string = "Configure"
-	YES       string = "Yes"
-	NO        string = "No"
-)
-
-func node0Handler(app *tview.Application, pages *tview.Pages) func(int, string) {
-	return func(buttonIndex int, buttonLabel string) {
-		if buttonLabel == YES {
-			// TODO: Print addressing, offer to configure, done
-
-			node0Form := forms.Node0Form(app, pages)
-			pages.AddPage("node0Form", node0Form, true, true)
-		} else {
-			regNodeForm := forms.RegNodeModalForm(app, pages)
-			pages.AddPage("regNodeConfig", regNodeForm, true, true)
-		}
-	}
-}
 
 func main() {
-	app := tview.NewApplication()
-	pages := tview.NewPages()
-
-	background := tview.NewBox().
-		SetBorder(false).
-		SetBackgroundColor(newt.ColorBlue)
-
-	node0 := tview.NewModal().
-		SetText("Do you wish for this node to be the one that runs the installation service (only one node may perform this function)?").
-		SetTextColor(tcell.ColorBlack).
-		SetDoneFunc(node0Handler(app, pages)).
-		SetBackgroundColor(newt.ColorGray).
-		SetButtonTextColor(tcell.ColorBlack).
-		SetButtonBackgroundColor(tcell.ColorDarkGray)
-
-	node0Buttons := []string{YES, NO}
-	node0.AddButtons(node0Buttons)
-
-	pages.AddPage("background", background, true, true).
-		AddPage("Node0", node0, true, true)
-
-	if err := app.SetRoot(pages, true).Run(); err != nil {
-		panic(err)
-	}
+	agent_tui.App()
 }

--- a/tools/agent_tui/net/nmtui.go
+++ b/tools/agent_tui/net/nmtui.go
@@ -6,7 +6,7 @@ import (
 	"os/exec"
 
 	"github.com/nmstate/nmstate/rust/src/go/nmstate/v2"
-	"github.com/openshift/agent-installer-utils/tools/agent_tui"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/dialogs"
 	"github.com/rivo/tview"
 )
 
@@ -19,31 +19,31 @@ func NMTUIRunner(app *tview.Application, pages *tview.Pages, treeView *tview.Tre
 			cmd.Stdout = os.Stdout
 			err := cmd.Run()
 			if err != nil {
-				agent_tui.PanicDialog(app, err)
+				dialogs.PanicDialog(app, err)
 			}
 		})
 		nm := nmstate.New()
 		state, err := nm.RetrieveNetState()
 		if err != nil {
-			agent_tui.PanicDialog(app, err)
+			dialogs.PanicDialog(app, err)
 		}
 
 		var netState NetState
 		if err := json.Unmarshal([]byte(state), &netState); err != nil {
-			agent_tui.PanicDialog(app, err)
+			dialogs.PanicDialog(app, err)
 		}
 
 		//netStatePage, err := modalNetStateJSONPage(&netState, pages)
 		if treeView == nil {
 			netStatePage, err := ModalTreeView(netState, pages)
 			if err != nil {
-				agent_tui.PanicDialog(app, err)
+				dialogs.PanicDialog(app, err)
 			}
 			pages.AddPage("netstate", netStatePage, true, true)
 		} else {
 			updatedTreeView, err := TreeView(netState, pages)
 			if err != nil {
-				agent_tui.PanicDialog(app, err)
+				dialogs.PanicDialog(app, err)
 			}
 			treeView.SetRoot(updatedTreeView.GetRoot())
 		}


### PR DESCRIPTION
This will allow for minimal code duplication while agent-tui is built in assisted-installer-agent as well.

Signed-off-by: Antoni Segura Puimedon <antoni@redhat.com>