### PR TITLE
[WIP] Use the latest base / builder image. Fix the bin path

### DIFF
--- a/images/Containerfile.ocp
+++ b/images/Containerfile.ocp
@@ -1,14 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.12 AS builder
-
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.13 AS builder
 WORKDIR /go/src/github.com/openshift/agent-installer-utils
 COPY . . 
 RUN dnf install -y gcc nmstate-devel nmstate-libs git && dnf clean all
 RUN ./hack/build.sh
 
-FROM registry.ci.openshift.org/ocp/4.12:base
-
-LABEL io.openshift.release.operator=true
-
+FROM registry.ci.openshift.org/ocp/4.13:base
 RUN dnf install -y nmstate-libs && dnf clean all
-
-COPY --from=builder /go/src/github.com/openshift/assisted-installer-agent/bin/agent-tui /usr/bin/agent-tui
+COPY --from=builder /go/src/github.com/openshift/agent-installer-utils/bin/agent-tui /usr/bin/agent-tui
+#LABEL io.openshift.release.operator=true


### PR DESCRIPTION
This patch fixes the ocp dockerfile in order to be usable in the CI for the test jobs (to build the `agent-utils-gotools` image