### PR TITLE
OCPBUGS-7731: Fix cancel user prompt

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -19,7 +19,7 @@ func App(app *tview.Application, config checks.Config) {
 
 	engine := checks.NewEngine(controller.GetChan(), config)
 
-	controller.Init()
+	controller.Init(engine.Size())
 	engine.Init()
 
 	if err := app.Run(); err != nil {

--- a/tools/agent_tui/checks/engine.go
+++ b/tools/agent_tui/checks/engine.go
@@ -194,3 +194,7 @@ func (e *Engine) Init() {
 		go chk.Run(e.channel, chk.Freq)
 	}
 }
+
+func (e *Engine) Size() int {
+	return len(e.checks)
+}

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -15,7 +15,7 @@ const (
 	RELEASE_IMAGE_LABEL     string = "Release Image"
 	CONFIGURE_BUTTON        string = "<Configure network>"
 	QUIT_BUTTON             string = "<Quit>"
-	CHECK_PAGE_NAME         string = "checkScreen"
+	PAGE_CHECKSCREEN        string = "checkScreen"
 )
 
 func (u *UI) markCheckSuccess(row int, col int) {
@@ -166,7 +166,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 
 	u.pages.SetBackgroundColor(newt.ColorBlue)
 
-	u.pages.AddPage(CHECK_PAGE_NAME, flex, true, true)
+	u.pages.AddPage(PAGE_CHECKSCREEN, flex, true, true)
 
-	u.app.SetRoot(u.pages, true).SetFocus(u.form).EnableMouse(true)
+	u.app.SetRoot(u.pages, true).SetFocus(u.form)
 }

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -106,10 +106,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 	u.form.SetBackgroundColor(newt.ColorGray)
 	u.form.SetButtonsAlign(tview.AlignCenter)
 	u.form.AddButton(CONFIGURE_BUTTON, func() {
-		u.setIsNMTuiActive(true)
-		f := u.NMTUIRunner(nil)
-		f()
-		u.setIsNMTuiActive(false)
+		u.ShowNMTUI(nil)
 	})
 	u.form.AddButton(QUIT_BUTTON, func() {
 		u.app.Stop()

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -100,7 +100,7 @@ func (c *Controller) Init() {
 				})
 			}
 
-			if c.ui.isNMTuiActive() {
+			if c.ui.IsNMTuiActive() {
 				continue
 			}
 

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -37,11 +37,18 @@ func (c *Controller) updateState(cr checks.CheckResult) {
 	}
 }
 
-func (c *Controller) Init() {
+func (c *Controller) receivedAllCheckResults(numChecks int) bool {
+	return len(c.checks) >= numChecks
+}
+
+func (c *Controller) Init(numChecks int) {
+
+	c.ui.ShowSplashScreen()
+
 	go func() {
 		for {
-			r := <-c.channel
-			c.updateState(r)
+			res := <-c.channel
+			c.updateState(res)
 
 			// When nmtui is shown the UI is suspended, so
 			// let's skip any update
@@ -49,52 +56,78 @@ func (c *Controller) Init() {
 				continue
 			}
 
-			// Update the widgets
-			switch r.Type {
-			case checks.CheckTypeReleaseImagePull:
+			// Keep the checks page continuously updated
+			c.updateCheckWidgets(res)
+
+			// Warming up, wait for at least the first
+			// set of check results
+			if !c.receivedAllCheckResults(numChecks) {
+				continue
+			}
+
+			// After receiving the initial results, let's
+			// show the timeout dialog if required
+			if c.ui.IsSplashScreenActive() {
 				c.ui.app.QueueUpdateDraw(func() {
-					if r.Success {
-						c.ui.markCheckSuccess(0, 0)
+					c.ui.HideSplashScreen()
+					if c.state {
+						c.ui.ShowTimeoutDialog()
 					} else {
-						c.ui.markCheckFail(0, 0)
-						c.ui.appendNewErrorToDetails("Release image pull error", r.Details)
+						c.ui.returnFocusToChecks()
 					}
 				})
-			case checks.CheckTypeReleaseImageHostDNS:
-				c.ui.app.QueueUpdateDraw(func() {
-					if r.Success {
-						c.ui.markCheckSuccess(1, 0)
-					} else {
-						c.ui.markCheckFail(1, 0)
-						c.ui.appendNewErrorToDetails("nslookup failure", r.Details)
-					}
-				})
-			case checks.CheckTypeReleaseImageHostPing:
-				c.ui.app.QueueUpdateDraw(func() {
-					if r.Success {
-						c.ui.markCheckSuccess(2, 0)
-					} else {
-						c.ui.markCheckFail(2, 0)
-						c.ui.appendNewErrorToDetails("ping failure", r.Details)
-					}
-				})
-			case checks.CheckTypeReleaseImageHttp:
-				c.ui.app.QueueUpdateDraw(func() {
-					if r.Success {
-						c.ui.markCheckSuccess(3, 0)
-					} else {
-						c.ui.markCheckFail(3, 0)
-						c.ui.appendNewErrorToDetails("http server not responding", r.Details)
-					}
-				})
+				continue
 			}
 
 			// A check failed while waiting for the countdown. Timeout dialog must be stopped
-			if !c.state && c.ui.isTimeoutDialogActive() {
+			if !c.state && c.ui.IsTimeoutDialogActive() {
 				c.ui.app.QueueUpdate(func() {
 					c.ui.cancelUserPrompt()
 				})
 			}
+
 		}
 	}()
+}
+
+func (c *Controller) updateCheckWidgets(res checks.CheckResult) {
+	// Update the widgets
+	switch res.Type {
+	case checks.CheckTypeReleaseImagePull:
+		c.ui.app.QueueUpdateDraw(func() {
+			if res.Success {
+				c.ui.markCheckSuccess(0, 0)
+			} else {
+				c.ui.markCheckFail(0, 0)
+				c.ui.appendNewErrorToDetails("Release image pull error", res.Details)
+			}
+		})
+	case checks.CheckTypeReleaseImageHostDNS:
+		c.ui.app.QueueUpdateDraw(func() {
+			if res.Success {
+				c.ui.markCheckSuccess(1, 0)
+			} else {
+				c.ui.markCheckFail(1, 0)
+				c.ui.appendNewErrorToDetails("nslookup failure", res.Details)
+			}
+		})
+	case checks.CheckTypeReleaseImageHostPing:
+		c.ui.app.QueueUpdateDraw(func() {
+			if res.Success {
+				c.ui.markCheckSuccess(2, 0)
+			} else {
+				c.ui.markCheckFail(2, 0)
+				c.ui.appendNewErrorToDetails("ping failure", res.Details)
+			}
+		})
+	case checks.CheckTypeReleaseImageHttp:
+		c.ui.app.QueueUpdateDraw(func() {
+			if res.Success {
+				c.ui.markCheckSuccess(3, 0)
+			} else {
+				c.ui.markCheckFail(3, 0)
+				c.ui.appendNewErrorToDetails("http server not responding", res.Details)
+			}
+		})
+	}
 }

--- a/tools/agent_tui/ui/nmtui.go
+++ b/tools/agent_tui/ui/nmtui.go
@@ -11,42 +11,43 @@ import (
 	"github.com/rivo/tview"
 )
 
-func (u *UI) NMTUIRunner(treeView *tview.TreeView) func() {
-	return func() {
-		u.app.Suspend(func() {
-			cmd := exec.Command("nmtui")
-			cmd.Stdin = os.Stdin
-			cmd.Stderr = os.Stderr
-			cmd.Stdout = os.Stdout
-			err := cmd.Run()
-			if err != nil {
-				dialogs.PanicDialog(u.app, err)
-			}
-		})
-		nm := nmstate.New()
-		state, err := nm.RetrieveNetState()
+func (u *UI) ShowNMTUI(treeView *tview.TreeView) {
+	u.nmtuiActive.Store(true)
+	defer u.nmtuiActive.Store(false)
+
+	u.app.Suspend(func() {
+		cmd := exec.Command("nmtui")
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		err := cmd.Run()
 		if err != nil {
 			dialogs.PanicDialog(u.app, err)
 		}
+	})
+	nm := nmstate.New()
+	state, err := nm.RetrieveNetState()
+	if err != nil {
+		dialogs.PanicDialog(u.app, err)
+	}
 
-		var netState net.NetState
-		if err := json.Unmarshal([]byte(state), &netState); err != nil {
+	var netState net.NetState
+	if err := json.Unmarshal([]byte(state), &netState); err != nil {
+		dialogs.PanicDialog(u.app, err)
+	}
+
+	//netStatePage, err := modalNetStateJSONPage(&netState, pages)
+	if treeView == nil {
+		netStatePage, err := u.ModalTreeView(netState)
+		if err != nil {
 			dialogs.PanicDialog(u.app, err)
 		}
-
-		//netStatePage, err := modalNetStateJSONPage(&netState, pages)
-		if treeView == nil {
-			netStatePage, err := u.ModalTreeView(netState)
-			if err != nil {
-				dialogs.PanicDialog(u.app, err)
-			}
-			u.pages.AddPage("netstate", netStatePage, true, true)
-		} else {
-			updatedTreeView, err := u.TreeView(netState)
-			if err != nil {
-				dialogs.PanicDialog(u.app, err)
-			}
-			treeView.SetRoot(updatedTreeView.GetRoot())
+		u.pages.AddPage("netstate", netStatePage, true, true)
+	} else {
+		updatedTreeView, err := u.TreeView(netState)
+		if err != nil {
+			dialogs.PanicDialog(u.app, err)
 		}
+		treeView.SetRoot(updatedTreeView.GetRoot())
 	}
 }

--- a/tools/agent_tui/ui/splashcreen.go
+++ b/tools/agent_tui/ui/splashcreen.go
@@ -1,0 +1,32 @@
+package ui
+
+import (
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+const (
+	PAGE_SPLASHSCREEN string = "splashscreen"
+)
+
+func (u *UI) createSplashScreen() {
+	u.splashScreen = tview.NewModal()
+	u.splashScreen.SetBackgroundColor(newt.ColorBlack).
+		SetBorderColor(newt.ColorBlack).
+		SetBorder(true)
+	u.splashScreen.SetText("Please wait, collecting initial check results")
+	u.pages.AddPage(PAGE_SPLASHSCREEN, u.splashScreen, true, false)
+}
+
+func (u *UI) ShowSplashScreen() {
+	u.app.SetFocus(u.splashScreen)
+	u.pages.ShowPage(PAGE_SPLASHSCREEN)
+}
+
+func (u *UI) HideSplashScreen() {
+	u.pages.HidePage(PAGE_SPLASHSCREEN)
+}
+
+func (u *UI) IsSplashScreenActive() bool {
+	return u.splashScreen.HasFocus()
+}

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -18,11 +18,13 @@ type UI struct {
 	timeoutModal        *tview.Modal    // popup window that times out
 	nmtuiActive         atomic.Bool
 	timeoutDialogActive atomic.Bool
+	timeoutDialogCancel chan bool
 }
 
 func NewUI(app *tview.Application, config checks.Config) *UI {
 	ui := &UI{
-		app: app,
+		app:                 app,
+		timeoutDialogCancel: make(chan bool),
 	}
 	ui.create(config)
 	return ui

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -47,11 +47,7 @@ func (u *UI) returnFocusToChecks() {
 	u.app.SetFocus(u.form.GetButton(0))
 }
 
-func (u *UI) setIsNMTuiActive(isActive bool) {
-	u.nmtuiActive.Store(isActive)
-}
-
-func (u *UI) isNMTuiActive() bool {
+func (u *UI) IsNMTuiActive() bool {
 	return u.nmtuiActive.Load()
 }
 

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -16,6 +16,7 @@ type UI struct {
 	details             *tview.TextView // where errors from checks are displayed
 	form                *tview.Form     // contains "Configure network" button
 	timeoutModal        *tview.Modal    // popup window that times out
+	splashScreen        *tview.Modal    // display initial waiting message
 	nmtuiActive         atomic.Bool
 	timeoutDialogActive atomic.Bool
 	timeoutDialogCancel chan bool
@@ -39,7 +40,7 @@ func (u *UI) GetPages() *tview.Pages {
 }
 
 func (u *UI) returnFocusToChecks() {
-	u.pages.SwitchToPage(CHECK_PAGE_NAME)
+	u.pages.SwitchToPage(PAGE_CHECKSCREEN)
 	// shifting focus back to the "Configure network"
 	// button requires setting focus in this sequence
 	// form -> form-button
@@ -55,7 +56,7 @@ func (u *UI) setIsTimeoutDialogActive(isActive bool) {
 	u.timeoutDialogActive.Store(isActive)
 }
 
-func (u *UI) isTimeoutDialogActive() bool {
+func (u *UI) IsTimeoutDialogActive() bool {
 	return u.timeoutDialogActive.Load()
 }
 
@@ -63,4 +64,5 @@ func (u *UI) create(config checks.Config) {
 	u.pages = tview.NewPages()
 	u.createCheckPage(config)
 	u.createTimeoutModal(config)
+	u.createSplashScreen()
 }


### PR DESCRIPTION
The current patch takes care of cancelling the countdown thread when the timeout dialog gets interrupted due a sudden failing check.
In addition to some refactoring to simplify the code, this patch also brings back the timeout dialog to one-off display (it will be shown only the first time)