### PR TITLE
skipping ping check for registry ci

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -1,6 +1,9 @@
 package agent_tui
 
 import (
+	"fmt"
+	"log"
+
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/dialogs"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/ui"
@@ -8,21 +11,53 @@ import (
 )
 
 func App(app *tview.Application, config checks.Config) {
+
+	if err := prepareConfig(&config); err != nil {
+		log.Fatal(err)
+	}
+
 	var appUI *ui.UI
 	if app == nil {
 		app = tview.NewApplication()
 	}
-
 	appUI = ui.NewUI(app, config)
-
 	controller := ui.NewController(appUI)
-
 	engine := checks.NewEngine(controller.GetChan(), config)
 
 	controller.Init(engine.Size())
 	engine.Init()
-
 	if err := app.Run(); err != nil {
 		dialogs.PanicDialog(app, err)
 	}
+}
+
+func prepareConfig(config *checks.Config) error {
+	// Set hostname
+	hostname, err := checks.ParseHostnameFromURL(config.ReleaseImageURL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	config.ReleaseImageHostname = hostname
+
+	// Set scheme
+	schemeHostnamePort, err := checks.ParseSchemeHostnamePortFromURL(config.ReleaseImageURL, "https://")
+	if err != nil {
+		log.Fatalf("Error creating <scheme>://<hostname>:<port> from releaseImageURL: %s\n", config.ReleaseImageURL)
+	}
+	config.ReleaseImageSchemeHostnamePort = schemeHostnamePort
+
+	// Set skipped checks
+	skippedPingUrls := []string{
+		"quay.io",
+		"registry.ci.openshift.org",
+	}
+
+	config.SkippedChecks = map[string]string{}
+	for _, s := range skippedPingUrls {
+		if s == hostname {
+			config.SkippedChecks[checks.CheckTypeReleaseImageHostPing] = fmt.Sprintf("%s does not respond to ping, ping skipped", hostname)
+		}
+	}
+
+	return nil
 }

--- a/tools/agent_tui/app_test.go
+++ b/tools/agent_tui/app_test.go
@@ -37,7 +37,7 @@ func TestChecksPage(t *testing.T) {
 					appConfig.ReleaseImageURL,
 					"✓ podman pull release image",
 					"✓ nslookup quay.io",
-					"✓ quay.io does not respond to ping, ping skipped")
+					"? quay.io does not respond to ping, ping skipped")
 			},
 		},
 		{


### PR DESCRIPTION
Also the ci registry does not support ping:

![immagine](https://user-images.githubusercontent.com/60063538/221548772-cdac98c7-4d1f-471f-9510-5bf8fdee6f29.png)

Thus, added a more generic mechanism to support skippings checks, with currently  an hard-coded configuration for the ping check (with some code simplifications)