### PR TITLE
AGENT-565: make the pull check mandatory, the other checks as non blocking

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -3,7 +3,6 @@ package agent_tui
 import (
 	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/dialogs"
@@ -36,35 +35,16 @@ func prepareConfig(config *checks.Config) error {
 	// Set hostname
 	hostname, err := checks.ParseHostnameFromURL(config.ReleaseImageURL)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	config.ReleaseImageHostname = hostname
 
 	// Set scheme
 	schemeHostnamePort, err := checks.ParseSchemeHostnamePortFromURL(config.ReleaseImageURL, "https://")
 	if err != nil {
-		log.Fatalf("Error creating <scheme>://<hostname>:<port> from releaseImageURL: %s\n", config.ReleaseImageURL)
+		return fmt.Errorf("Error creating <scheme>://<hostname>:<port> from releaseImageURL: %s\n", config.ReleaseImageURL)
 	}
 	config.ReleaseImageSchemeHostnamePort = schemeHostnamePort
-
-	// Set skipped checks
-	skippedPingUrls := []string{
-		`quay\.io`,
-		`registry\..*ci\.openshift\.org`,
-	}
-
-	config.SkippedChecks = map[string]string{}
-	for _, s := range skippedPingUrls {
-
-		matched, err := regexp.MatchString(s, hostname)
-		if err != nil {
-			return err
-		}
-
-		if matched {
-			config.SkippedChecks[checks.CheckTypeReleaseImageHostPing] = fmt.Sprintf("%s does not respond to ping, ping skipped", hostname)
-		}
-	}
 
 	return nil
 }

--- a/tools/agent_tui/app_test.go
+++ b/tools/agent_tui/app_test.go
@@ -34,10 +34,10 @@ func TestChecksPage(t *testing.T) {
 				tester.SelectItem(ui.YES_BUTTON)
 				tester.WaitForScreenContent(
 					"Agent installer network boot setup",
-					appConfig.ReleaseImageURL,
-					"✓ podman pull release image",
+					"✓ quay.io/openshift-release-dev/ocp-release:4.12.2-x86_64",
 					"✓ nslookup quay.io",
-					"? quay.io does not respond to ping, ping skipped")
+					"✖ ping quay.io",
+					"✓ quay.io responds to http GET")
 			},
 		},
 		{
@@ -50,10 +50,10 @@ func TestChecksPage(t *testing.T) {
 				tester := app.Start(appConfig)
 				tester.WaitForScreenContent(
 					"Agent installer network boot setup",
-					appConfig.ReleaseImageURL,
-					"✖ podman pull release image",
+					"✖ localhost:8888/missing",
 					"✖ nslookup localhost",
-					"✓ ping localhost")
+					"✓ ping localhost",
+					"✖ localhost responds to http GET")
 
 				// TODO: There is a limitation in apptester
 				// where the full error details are not displayed

--- a/tools/agent_tui/checks/engine.go
+++ b/tools/agent_tui/checks/engine.go
@@ -22,7 +22,6 @@ type Config struct {
 	ReleaseImageURL string
 	LogPath         string
 
-	SkippedChecks                  map[string]string
 	ReleaseImageHostname           string
 	ReleaseImageSchemeHostnamePort string
 }
@@ -167,17 +166,11 @@ func NewEngine(c chan CheckResult, config Config) *Engine {
 		logger:  logger,
 	}
 
-	for _, c := range []*Check{
+	e.checks = []*Check{
 		e.newRegistryImagePullCheck(config),
 		e.newReleaseImageHostDNSCheck(config),
 		e.newReleaseImageHostPingCheck(config),
 		e.newReleaseImageHttpCheck(config),
-	} {
-		if reason, skipped := config.SkippedChecks[c.Type]; skipped {
-			logger.Infof(reason)
-			continue
-		}
-		e.checks = append(e.checks, c)
 	}
 
 	return e

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -18,29 +18,56 @@ const (
 	PAGE_CHECKSCREEN        string = "checkScreen"
 )
 
-func (u *UI) markCheckSuccess(row int, col int) {
-	u.checks.SetCell(row, col, &tview.TableCell{
+func (u *UI) SetPullCheck(cr checks.CheckResult) {
+	u.setCheck(u.primaryCheck, cr, 1, "release image pull error")
+}
+
+func (u *UI) SetDNSCheck(cr checks.CheckResult) {
+	u.setCheck(u.checks, cr, 0, "nslookup failure")
+}
+
+func (u *UI) SetPingCheck(cr checks.CheckResult) {
+	u.setCheck(u.checks, cr, 1, "ping failure")
+}
+
+func (u *UI) SetHttpGetCheck(cr checks.CheckResult) {
+	u.setCheck(u.checks, cr, 2, "http server not responding")
+}
+
+func (u *UI) setCheck(table *tview.Table, cr checks.CheckResult, row int, msg string) {
+	u.app.QueueUpdateDraw(func() {
+		if cr.Success {
+			u.markCheckSuccess(table, row, 0)
+		} else {
+			u.markCheckFail(table, row, 0)
+			u.appendNewErrorToDetails(msg, cr.Details)
+		}
+	})
+}
+
+func (u *UI) markCheckSuccess(table *tview.Table, row int, col int) {
+	table.SetCell(row, col, &tview.TableCell{
 		Text:            " ✓",
 		Color:           tcell.ColorLimeGreen,
 		BackgroundColor: newt.ColorGray})
 }
 
-func (u *UI) markCheckFail(row int, col int) {
-	u.checks.SetCell(row, col, &tview.TableCell{
+func (u *UI) markCheckFail(table *tview.Table, row int, col int) {
+	table.SetCell(row, col, &tview.TableCell{
 		Text:            " ✖",
 		Color:           newt.ColorRed,
 		BackgroundColor: newt.ColorGray})
 }
 
-func (u *UI) markCheckUnknown(row int, col int) {
-	u.checks.SetCell(row, col, &tview.TableCell{
+func (u *UI) markCheckUnknown(table *tview.Table, row int, col int) {
+	table.SetCell(row, col, &tview.TableCell{
 		Text:            " ?",
 		Color:           newt.ColorBlack,
 		BackgroundColor: newt.ColorGray})
 }
 
-func (u *UI) setCheckDescription(row int, col int, description string) {
-	u.checks.SetCell(row, col, &tview.TableCell{
+func (u *UI) setCheckDescription(table *tview.Table, row int, col int, description string) {
+	table.SetCell(row, col, &tview.TableCell{
 		Text:            description,
 		Color:           newt.ColorBlack,
 		BackgroundColor: newt.ColorGray})
@@ -59,43 +86,35 @@ func (u *UI) appendToDetails(newLines string) {
 	u.details.SetText(current + newLines)
 }
 
-func (u *UI) setCheckWidget(row int, checkType string, desc string, config checks.Config) {
-	u.markCheckUnknown(row, 0)
-
-	if skipReason, skipped := config.SkippedChecks[checkType]; skipped {
-		u.setCheckDescription(row, 1, skipReason)
-		return
-	}
+func (u *UI) setCheckWidget(table *tview.Table, row int, checkType string, desc string, config checks.Config) {
+	u.markCheckUnknown(table, row, 0)
 
 	checkDesc := desc
 	if strings.Contains(desc, "%s") {
 		checkDesc = fmt.Sprintf(desc, config.ReleaseImageHostname)
 	}
-	u.setCheckDescription(row, 1, checkDesc)
+	u.setCheckDescription(table, row, 1, checkDesc)
 
 }
 
 func (u *UI) createCheckPage(config checks.Config) {
-	u.envVars = tview.NewTextView()
-	u.envVars.SetBorder(true)
-	u.envVars.SetBorderColor(newt.ColorBlack)
-	u.envVars.SetBackgroundColor(newt.ColorGray)
-	u.envVars.SetTitleColor(newt.ColorBlack)
-	u.envVars.SetTitle("  Release image URL  ")
-	u.envVars.SetText("\n" + config.ReleaseImageURL)
-	u.envVars.SetTextColor(newt.ColorBlack)
+	u.primaryCheck = tview.NewTable()
+	u.primaryCheck.SetBorder(true)
+	u.primaryCheck.SetTitle("  Release image URL  ")
+	u.primaryCheck.SetBorderColor(newt.ColorBlack)
+	u.primaryCheck.SetBackgroundColor(newt.ColorGray)
+	u.primaryCheck.SetTitleColor(newt.ColorBlack)
+	u.setCheckWidget(u.primaryCheck, 1, checks.CheckTypeReleaseImagePull, config.ReleaseImageURL, config)
 
 	u.checks = tview.NewTable()
 	u.checks.SetBorder(true)
-	u.checks.SetTitle("  Checks  ")
+	u.checks.SetTitle("  Additional checks  ")
 	u.checks.SetBorderColor(newt.ColorBlack)
 	u.checks.SetBackgroundColor(newt.ColorGray)
 	u.checks.SetTitleColor(newt.ColorBlack)
-
-	u.setCheckWidget(0, checks.CheckTypeReleaseImagePull, "podman pull release image", config)
-	u.setCheckWidget(1, checks.CheckTypeReleaseImageHostDNS, "nslookup %s", config)
-	u.setCheckWidget(2, checks.CheckTypeReleaseImageHostPing, "ping %s", config)
-	u.setCheckWidget(3, checks.CheckTypeReleaseImageHttp, "%s responds to http GET", config)
+	u.setCheckWidget(u.checks, 0, checks.CheckTypeReleaseImageHostDNS, "nslookup %s", config)
+	u.setCheckWidget(u.checks, 1, checks.CheckTypeReleaseImageHostPing, "ping %s", config)
+	u.setCheckWidget(u.checks, 2, checks.CheckTypeReleaseImageHttp, "%s responds to http GET", config)
 
 	u.details = tview.NewTextView()
 	u.details.SetBorder(true)
@@ -149,7 +168,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 	//         number-of-lines-to-give-2nd-row,..etc)
 	// 0 means fill
 	u.grid = tview.NewGrid().SetRows(5, 6, 0, 3).SetColumns(0).
-		AddItem(u.envVars, 0, 0, 1, 1, 0, 0, false).
+		AddItem(u.primaryCheck, 0, 0, 1, 1, 0, 0, false).
 		AddItem(u.checks, 1, 0, 1, 1, 0, 0, false).
 		AddItem(u.details, 2, 0, 1, 1, 0, 0, false).
 		AddItem(u.form, 3, 0, 1, 1, 0, 0, false)

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -27,13 +27,10 @@ func (c *Controller) GetChan() chan checks.CheckResult {
 
 func (c *Controller) updateState(cr checks.CheckResult) {
 	c.checks[cr.Type] = cr
-	c.state = true
 
-	for _, res := range c.checks {
-		if !res.Success {
-			c.state = false
-			break
-		}
+	switch cr.Type {
+	case checks.CheckTypeReleaseImagePull:
+		c.state = cr.Success
 	}
 }
 
@@ -94,40 +91,12 @@ func (c *Controller) updateCheckWidgets(res checks.CheckResult) {
 	// Update the widgets
 	switch res.Type {
 	case checks.CheckTypeReleaseImagePull:
-		c.ui.app.QueueUpdateDraw(func() {
-			if res.Success {
-				c.ui.markCheckSuccess(0, 0)
-			} else {
-				c.ui.markCheckFail(0, 0)
-				c.ui.appendNewErrorToDetails("Release image pull error", res.Details)
-			}
-		})
+		c.ui.SetPullCheck(res)
 	case checks.CheckTypeReleaseImageHostDNS:
-		c.ui.app.QueueUpdateDraw(func() {
-			if res.Success {
-				c.ui.markCheckSuccess(1, 0)
-			} else {
-				c.ui.markCheckFail(1, 0)
-				c.ui.appendNewErrorToDetails("nslookup failure", res.Details)
-			}
-		})
+		c.ui.SetDNSCheck(res)
 	case checks.CheckTypeReleaseImageHostPing:
-		c.ui.app.QueueUpdateDraw(func() {
-			if res.Success {
-				c.ui.markCheckSuccess(2, 0)
-			} else {
-				c.ui.markCheckFail(2, 0)
-				c.ui.appendNewErrorToDetails("ping failure", res.Details)
-			}
-		})
+		c.ui.SetPingCheck(res)
 	case checks.CheckTypeReleaseImageHttp:
-		c.ui.app.QueueUpdateDraw(func() {
-			if res.Success {
-				c.ui.markCheckSuccess(3, 0)
-			} else {
-				c.ui.markCheckFail(3, 0)
-				c.ui.appendNewErrorToDetails("http server not responding", res.Details)
-			}
-		})
+		c.ui.SetHttpGetCheck(res)
 	}
 }

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -10,8 +10,8 @@ import (
 type UI struct {
 	app                 *tview.Application
 	pages               *tview.Pages
-	grid                *tview.Grid     // layout for the checks page
-	envVars             *tview.TextView // displays release image URL
+	grid                *tview.Grid // layout for the checks page
+	primaryCheck        *tview.Table
 	checks              *tview.Table    // summary of all checks
 	details             *tview.TextView // where errors from checks are displayed
 	form                *tview.Form     // contains "Configure network" button


### PR DESCRIPTION
Now only the pull check can interrupt the timeout dialog if failing.
All the other checks are still being executed in parallel, but their eventual failure will not prevent the agent-tui to automatically close.
Removed also the previous skipping logic.