### PR TITLE
Allow the user to scroll the content of the details view

### DIFF
--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -20,6 +20,9 @@ type UI struct {
 	nmtuiActive         atomic.Value
 	timeoutDialogActive atomic.Value
 	timeoutDialogCancel chan bool
+
+	focusableItems []tview.Primitive // the list of widgets that can be focused
+	focusedItem    int               // the current focused widget
 }
 
 func NewUI(app *tview.Application, config checks.Config) *UI {


### PR DESCRIPTION
Aallow the user to switch the focus between the form buttons and details pane (when visibile). In this way, the user could scroll the details view content by using the up/down arrow keys.