### PR TITLE
AGENT-508: add dockerfile for generating release image

### DIFF
--- a/images/Dockerfile.ocp
+++ b/images/Dockerfile.ocp
@@ -1,0 +1,9 @@
+    FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.14 AS builder
+    WORKDIR /go/src/github.com/openshift/agent-installer-utils
+    COPY . .
+    RUN dnf install -y gcc nmstate-devel nmstate-libs && dnf clean all
+    RUN ./hack/build.sh
+    FROM registry.ci.openshift.org/ocp/4.14:base
+    RUN dnf install -y nmstate-libs && dnf clean all
+    COPY --from=builder /go/src/github.com/openshift/agent-installer-utils/bin/agent-tui /usr/bin/agent-tui
+    #LABEL io.openshift.release.operator=true


### PR DESCRIPTION
This is a preliminary step to start moving the dockerfile within the repo (currently defined in the [CI config](https://github.com/openshift/release/blob/b5adf9186520e72259f9605fd4b5ece6345464aa/ci-operator/config/openshift/agent-installer-utils/openshift-agent-installer-utils-main.yaml#L13-L23))