### PR TITLE
AGENT-597: Include Doozer build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# See pkg/version/version.go for details
+SOURCE_GIT_COMMIT ?= $(shell git rev-parse --verify 'HEAD^{commit}')
+BUILD_VERSION ?= $(shell git describe --always --abbrev=40 --dirty)
+
+VERSION_URI ?= github.com/openshift/agent-installer-utils/pkg/version
+RELEASE_IMAGE ?= quay.io/openshift-release-dev/ocp-release:4.12.0-rc.7-x86_64
+
+.PHONY:clean
+clean:
+	rm -rf bin/
+
+.PHONY: lint
+lint:
+	golangci-lint run -v
+
+.PHONY: build
+build: clean lint
+	hack/build.sh ${VERSION_URI} ${SOURCE_GIT_COMMIT} ${BUILD_VERSION}
+
+.PHONY: run
+run: build
+	RELEASE_IMAGE=${RELEASE_IMAGE} SOURCE_GIT_COMMIT=${SOURCE_GIT_COMMIT} BUILD_VERSION=${BUILD_VERSION} ./bin/agent-tui

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,6 +16,14 @@ function go_version_check() {
 
 function build() {
 	declare -r mode=${MODE:-release}
+	VERSION_URI=$1
+	SOURCE_GIT_COMMIT=$2
+	BUILD_VERSION=$3
+
+	echo "Agent tui git version: ${SOURCE_GIT_COMMIT}"
+	echo "Agent tui build version: ${BUILD_VERSION}"
+
+	export LDFLAGS="-X ${VERSION_URI}.Commit=${SOURCE_GIT_COMMIT} -X ${VERSION_URI}.Raw=${BUILD_VERSION}"
 
 	case "$mode" in
 	release)
@@ -38,5 +46,8 @@ function build() {
 # Only run this if not being sourced
 if ! (return 0 2>/dev/null); then
 	go_version_check
-	build
+	VERSION_URI=$1
+	SOURCE_GIT_COMMIT=$2
+	BUILD_VERSION=$3
+	build $VERSION_URI $SOURCE_GIT_COMMIT $BUILD_VERSION
 fi

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,13 @@
+// Package version includes the version information.
+package version
+
+var (
+	// Raw is the string representation of the version. This will be replaced
+	// with the calculated version at build time.
+	// Set via LDFLAGS in hack/build.sh.
+	Raw = "was not built with version info"
+
+	// Commit is the commit hash from which the agent-installer-utils was built.
+	// Set via LDFLAGS in hack/build.sh.
+	Commit = ""
+)

--- a/tools/agent_tui/checks/engine.go
+++ b/tools/agent_tui/checks/engine.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"time"
 
+	"github.com/openshift/agent-installer-utils/pkg/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -159,6 +160,8 @@ func NewEngine(c chan CheckResult, config Config) *Engine {
 	logger.Out = f
 
 	logger.Infof("Release Image URL: %s", config.ReleaseImageURL)
+	logger.Infof("Agent TUI git version: %s", version.Commit)
+	logger.Infof("Agent TUI build version: %s", version.Raw)
 
 	e := &Engine{
 		checks:  checks,


### PR DESCRIPTION
Added a Makefile with targets such as `clean`, `lint`, `build`, and `run`. The new variables such as `SOURCE_GIT_COMMIT` and `BUILD_VERSION` are logged in the log file.