### PR TITLE
AGENT-629: add image to the release payload

### DIFF
--- a/images/Dockerfile.ocp
+++ b/images/Dockerfile.ocp
@@ -6,4 +6,4 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.14 AS 
     FROM registry.ci.openshift.org/ocp/4.14:base
     RUN dnf install -y nmstate-libs && dnf clean all
     COPY --from=builder /go/src/github.com/openshift/agent-installer-utils/bin/agent-tui /usr/bin/agent-tui
-    #LABEL io.openshift.release.operator=true
+    LABEL io.openshift.release.operator=true


### PR DESCRIPTION
This patch enables the include of the agent-installer-utils image into the release payload