### PR TITLE
OCPBUGS-XXXXX: fix agent-tui stuck on boot 

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -9,7 +9,7 @@ import (
 	"github.com/rivo/tview"
 )
 
-func App(app *tview.Application, config checks.Config) {
+func App(app *tview.Application, config checks.Config, checkFuncs ...checks.CheckFunctions) {
 
 	if err := prepareConfig(&config); err != nil {
 		log.Fatal(err)
@@ -21,7 +21,7 @@ func App(app *tview.Application, config checks.Config) {
 	}
 	appUI = ui.NewUI(app, config)
 	controller := ui.NewController(appUI)
-	engine := checks.NewEngine(controller.GetChan(), config)
+	engine := checks.NewEngine(controller.GetChan(), config, checkFuncs...)
 
 	controller.Init(engine.Size())
 	engine.Init()

--- a/tools/agent_tui/checks/engine.go
+++ b/tools/agent_tui/checks/engine.go
@@ -50,104 +50,49 @@ type Engine struct {
 	logger  *logrus.Logger
 }
 
-type checkFunction func() ([]byte, error)
+type CheckFunction func(checkType string, config Config) ([]byte, error)
 
-func (e *Engine) createCheckResult(f checkFunction, checkType string) CheckResult {
-	output, err := f()
+func createCheckResult(f CheckFunction, checkType string, config Config, l *logrus.Logger) CheckResult {
+	output, err := f(checkType, config)
 	result := CheckResult{
 		Type:    checkType,
 		Success: err == nil,
 		Details: string(output),
 	}
 	if result.Success {
-		e.logger.Infof("%s check successful: %s", checkType, result.Details)
+		l.Infof("%s check successful: %s", checkType, result.Details)
 	} else {
-		e.logger.Warnf("%s check failed with error: %s", checkType, result.Details)
+		l.Warnf("%s check failed with error: %s", checkType, result.Details)
 	}
 	return result
 }
 
-func (e *Engine) newRegistryImagePullCheck(config Config) *Check {
-	ctype := CheckTypeReleaseImagePull
-	return &Check{
-		Type: ctype,
-		Freq: 5 * time.Second,
-		Run: func(c chan CheckResult, freq time.Duration) {
-			for {
-				checkFunction := func() ([]byte, error) {
-					return exec.Command("podman", "pull", config.ReleaseImageURL).CombinedOutput()
-				}
-				c <- e.createCheckResult(checkFunction, ctype)
-				time.Sleep(freq)
-			}
-		},
-	}
+type CheckFunctions map[string]CheckFunction
+
+var defaultCheckFunctions = CheckFunctions{
+	CheckTypeReleaseImagePull: func(checkType string, c Config) ([]byte, error) {
+		return exec.Command("podman", "pull", c.ReleaseImageURL).CombinedOutput()
+	},
+	CheckTypeReleaseImageHostDNS: func(checkType string, c Config) ([]byte, error) {
+		return exec.Command("nslookup", c.ReleaseImageHostname).CombinedOutput()
+	},
+	CheckTypeReleaseImageHostPing: func(checkType string, c Config) ([]byte, error) {
+		return exec.Command("ping", "-c", "4", c.ReleaseImageHostname).CombinedOutput()
+	},
+	CheckTypeReleaseImageHttp: func(checkType string, c Config) ([]byte, error) {
+		resp, err := http.Get(c.ReleaseImageSchemeHostnamePort)
+		if err != nil {
+			return []byte(err.Error()), err
+		} else {
+			// server replied with http response
+			// as long as there is a response, the check
+			// is a success.
+			return []byte(resp.Status), err
+		}
+	},
 }
 
-func (e *Engine) newReleaseImageHostDNSCheck(config Config) *Check {
-	ctype := CheckTypeReleaseImageHostDNS
-	return &Check{
-		Type: ctype,
-		Freq: 5 * time.Second,
-		Run: func(c chan CheckResult, freq time.Duration) {
-			for {
-				checkFunction := func() ([]byte, error) {
-					return exec.Command("nslookup", config.ReleaseImageHostname).CombinedOutput()
-				}
-				c <- e.createCheckResult(checkFunction, ctype)
-				time.Sleep(freq)
-			}
-		},
-	}
-}
-
-func (e *Engine) newReleaseImageHostPingCheck(config Config) *Check {
-	ctype := CheckTypeReleaseImageHostPing
-	return &Check{
-		Type: ctype,
-		Freq: 5 * time.Second,
-		Run: func(c chan CheckResult, freq time.Duration) {
-			for {
-				checkFunction := func() ([]byte, error) {
-					return exec.Command("ping", "-c", "4", config.ReleaseImageHostname).CombinedOutput()
-				}
-				c <- e.createCheckResult(checkFunction, ctype)
-				time.Sleep(freq)
-			}
-		},
-	}
-}
-
-// This check verifies whether there is a http server response
-// when schemeHostnamePort is queried. This does not check
-// if the release image exists.
-func (e *Engine) newReleaseImageHttpCheck(config Config) *Check {
-
-	ctype := CheckTypeReleaseImageHttp
-	return &Check{
-		Type: ctype,
-		Freq: 5 * time.Second,
-		Run: func(c chan CheckResult, freq time.Duration) {
-			for {
-				checkFunction := func() ([]byte, error) {
-					resp, err := http.Get(config.ReleaseImageSchemeHostnamePort)
-					if err != nil {
-						return []byte(err.Error()), err
-					} else {
-						// server replied with http response
-						// as long as there is a response, the check
-						// is a success.
-						return []byte(resp.Status), err
-					}
-				}
-				c <- e.createCheckResult(checkFunction, ctype)
-				time.Sleep(freq)
-			}
-		},
-	}
-}
-
-func NewEngine(c chan CheckResult, config Config) *Engine {
+func NewEngine(c chan CheckResult, config Config, checkFuncs ...CheckFunctions) *Engine {
 	checks := []*Check{}
 	logger := logrus.New()
 
@@ -163,20 +108,32 @@ func NewEngine(c chan CheckResult, config Config) *Engine {
 	logger.Infof("Agent TUI git version: %s", version.Commit)
 	logger.Infof("Agent TUI build version: %s", version.Raw)
 
-	e := &Engine{
+	cf := defaultCheckFunctions
+	if len(checkFuncs) > 0 {
+		cf = checkFuncs[0]
+	}
+
+	// create checks
+	for cType, cFunc := range cf {
+		ct := cType
+		cf := cFunc
+		checks = append(checks, &Check{
+			Type: ct,
+			Freq: 5 * time.Second,
+			Run: func(c chan CheckResult, freq time.Duration) {
+				for {
+					c <- createCheckResult(cf, ct, config, logger)
+					time.Sleep(freq)
+				}
+			},
+		})
+	}
+
+	return &Engine{
 		checks:  checks,
 		channel: c,
 		logger:  logger,
 	}
-
-	e.checks = []*Check{
-		e.newRegistryImagePullCheck(config),
-		e.newReleaseImageHostDNSCheck(config),
-		e.newReleaseImageHostPingCheck(config),
-		e.newReleaseImageHttpCheck(config),
-	}
-
-	return e
 }
 
 func (e *Engine) Init() {

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -88,6 +88,14 @@ func (c *Controller) Init(numChecks int) {
 				})
 			}
 
+			// A previously failed checked passed, so if the user never interacted with the ui
+			// then it's safe to display the timeout dialog
+			if c.state && !c.ui.IsTimeoutDialogActive() && !c.ui.IsDirty() {
+				c.ui.app.QueueUpdateDraw(func() {
+					c.ui.ShowTimeoutDialog()
+				})
+			}
+
 		}
 	}()
 }


### PR DESCRIPTION
Currently when the agent-tui is kicked off during the first boot there's no guarantee that the network will be fully working, thus initially the check could fail and just after a while immediately recover to a green situation, without an explicit user intervention. But the timeout dialog is not activated, and the agent-tui remains active without allowing the boot process to proceed.

This patch fixes the bug by re-activating the timeout dialog if a previously failed check becomes green _and_ if the user didn't interact with the interface. So, as long as the scenario remains stable for 20 seconds, the agent-tui will automatically get closed. 

