### PR TITLE
AGENT-464: Refactor UI for Rendezvous node IP entry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.5.4 h1:TGU4tSjD3sCL788vFNeJnTdzpNKIw1H5dgLnJRQVv/k=
 github.com/gdamore/tcell/v2 v2.5.4/go.mod h1:dZgRy5v4iMobMEcWNYBtREnDZAT9DYmfqIkrgEMxLyw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=

--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -31,6 +31,7 @@ func App(app *tview.Application, rendezvousIP string, config checks.Config, chec
 	logger.Infof("Release Image URL: %s", config.ReleaseImageURL)
 	logger.Infof("Agent TUI git version: %s", version.Commit)
 	logger.Infof("Agent TUI build version: %s", version.Raw)
+	logger.Infof("NODE_ZERO_IP: %s", rendezvousIP)
 
 	var appUI *ui.UI
 	if app == nil {

--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -1,29 +1,46 @@
 package agent_tui
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"os"
 
+	"github.com/openshift/agent-installer-utils/pkg/version"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/ui"
 	"github.com/rivo/tview"
+	"github.com/sirupsen/logrus"
 )
 
-func App(app *tview.Application, config checks.Config, checkFuncs ...checks.CheckFunctions) {
+func App(app *tview.Application, rendezvousIP string, config checks.Config, checkFuncs ...checks.CheckFunctions) {
 
 	if err := prepareConfig(&config); err != nil {
 		log.Fatal(err)
 	}
 
+	logger := logrus.New()
+	// initialize log
+	f, err := os.OpenFile(config.LogPath, os.O_RDWR|os.O_CREATE, 0644)
+	if errors.Is(err, os.ErrNotExist) {
+		// handle the case where the file doesn't exist
+		fmt.Printf("Error creating log file %s\n", config.LogPath)
+	}
+	logger.Out = f
+
+	logger.Infof("Release Image URL: %s", config.ReleaseImageURL)
+	logger.Infof("Agent TUI git version: %s", version.Commit)
+	logger.Infof("Agent TUI build version: %s", version.Raw)
+
 	var appUI *ui.UI
 	if app == nil {
 		app = tview.NewApplication()
 	}
-	appUI = ui.NewUI(app, config)
+	appUI = ui.NewUI(app, config, logger)
 	controller := ui.NewController(appUI)
-	engine := checks.NewEngine(controller.GetChan(), config, checkFuncs...)
+	engine := checks.NewEngine(controller.GetChan(), config, logger, checkFuncs...)
 
-	controller.Init(engine.Size())
+	controller.Init(engine.Size(), rendezvousIP)
 	engine.Init()
 	if err := app.Run(); err != nil {
 		log.Fatal(err)

--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -33,7 +33,7 @@ func App(app *tview.Application, rendezvousIP string, config checks.Config, chec
 	logger.Infof("Release Image URL: %s", config.ReleaseImageURL)
 	logger.Infof("Agent TUI git version: %s", version.Commit)
 	logger.Infof("Agent TUI build version: %s", version.Raw)
-	logger.Infof("NODE_ZERO_IP: %s", rendezvousIP)
+	logger.Infof("Rendezvous IP: %s", rendezvousIP)
 
 	var appUI *ui.UI
 	if app == nil {

--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -6,8 +6,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/openshift/agent-installer-utils/pkg/version"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/ui"
 	"github.com/rivo/tview"
 	"github.com/sirupsen/logrus"
@@ -35,6 +37,21 @@ func App(app *tview.Application, rendezvousIP string, config checks.Config, chec
 
 	var appUI *ui.UI
 	if app == nil {
+		theme := tview.Theme{
+			PrimitiveBackgroundColor:    newt.ColorGray,
+			ContrastBackgroundColor:     newt.ColorBlue, // inputfield background color
+			MoreContrastBackgroundColor: newt.ColorGray,
+			BorderColor:                 tcell.ColorDefault,
+			TitleColor:                  tcell.ColorDefault,
+			GraphicsColor:               tcell.ColorDefault,
+			PrimaryTextColor:            tcell.ColorDefault,
+			SecondaryTextColor:          newt.ColorBlue, // form field labels
+			TertiaryTextColor:           tcell.ColorDefault,
+			InverseTextColor:            tcell.ColorDefault,
+			ContrastSecondaryTextColor:  tcell.ColorDefault,
+		}
+		tview.Styles = theme
+
 		app = tview.NewApplication()
 	}
 	appUI = ui.NewUI(app, config, logger)

--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -41,10 +41,10 @@ func App(app *tview.Application, rendezvousIP string, config checks.Config, chec
 			PrimitiveBackgroundColor:    newt.ColorGray,
 			ContrastBackgroundColor:     newt.ColorBlue, // inputfield background color
 			MoreContrastBackgroundColor: newt.ColorGray,
-			BorderColor:                 tcell.ColorDefault,
+			BorderColor:                 newt.ColorBlack,
 			TitleColor:                  tcell.ColorDefault,
 			GraphicsColor:               tcell.ColorDefault,
-			PrimaryTextColor:            tcell.ColorDefault,
+			PrimaryTextColor:            newt.ColorBlack,
 			SecondaryTextColor:          newt.ColorBlue, // form field labels
 			TertiaryTextColor:           tcell.ColorDefault,
 			InverseTextColor:            tcell.ColorDefault,

--- a/tools/agent_tui/apptester_test.go
+++ b/tools/agent_tui/apptester_test.go
@@ -64,7 +64,7 @@ func NewAppTester(t *testing.T, debug ...bool) *AppTester {
 
 // Starts a new Agent TUI in background
 func (a *AppTester) Start(config checks.Config) *AppTester {
-	go App(a.app, config, checks.CheckFunctions{
+	go App(a.app, "192.168.111.80", config, checks.CheckFunctions{
 		checks.CheckTypeReleaseImageHostDNS:  a.wrapper,
 		checks.CheckTypeReleaseImageHostPing: a.wrapper,
 		checks.CheckTypeReleaseImageHttp:     a.wrapper,

--- a/tools/agent_tui/checks/engine.go
+++ b/tools/agent_tui/checks/engine.go
@@ -1,14 +1,10 @@
 package checks
 
 import (
-	"errors"
-	"fmt"
 	"net/http"
-	"os"
 	"os/exec"
 	"time"
 
-	"github.com/openshift/agent-installer-utils/pkg/version"
 	"github.com/sirupsen/logrus"
 )
 
@@ -92,21 +88,8 @@ var defaultCheckFunctions = CheckFunctions{
 	},
 }
 
-func NewEngine(c chan CheckResult, config Config, checkFuncs ...CheckFunctions) *Engine {
+func NewEngine(c chan CheckResult, config Config, logger *logrus.Logger, checkFuncs ...CheckFunctions) *Engine {
 	checks := []*Check{}
-	logger := logrus.New()
-
-	// initialize log
-	f, err := os.OpenFile(config.LogPath, os.O_RDWR|os.O_CREATE, 0644)
-	if errors.Is(err, os.ErrNotExist) {
-		// handle the case where the file doesn't exist
-		fmt.Printf("Error creating log file %s\n", config.LogPath)
-	}
-	logger.Out = f
-
-	logger.Infof("Release Image URL: %s", config.ReleaseImageURL)
-	logger.Infof("Agent TUI git version: %s", version.Commit)
-	logger.Infof("Agent TUI build version: %s", version.Raw)
 
 	cf := defaultCheckFunctions
 	if len(checkFuncs) > 0 {

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -11,6 +11,8 @@ import (
 func main() {
 	releaseImage := os.Getenv("RELEASE_IMAGE")
 	logPath := os.Getenv("AGENT_TUI_LOG_PATH")
+	nodeZeroIP := os.Getenv("NODE_ZERO_IP")
+
 	if releaseImage == "" {
 		fmt.Println("RELEASE_IMAGE environment variable is not specified.")
 		fmt.Println("Unable to perform connectivity checks.")
@@ -25,5 +27,5 @@ func main() {
 		ReleaseImageURL: releaseImage,
 		LogPath:         logPath,
 	}
-	agent_tui.App(nil, config)
+	agent_tui.App(nil, nodeZeroIP, config)
 }

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -11,6 +11,10 @@ import (
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/ui"
 )
 
+const (
+	RENDEZVOUS_IP_TEMPLATE_VALUE = "{{.RendezvousIP}}"
+)
+
 func main() {
 	releaseImage := os.Getenv("RELEASE_IMAGE")
 	logPath := os.Getenv("AGENT_TUI_LOG_PATH")
@@ -46,6 +50,9 @@ func getRendezvousIP() string {
 			return ""
 		}
 		nodeZeroIP = envMap["NODE_ZERO_IP"]
+		if nodeZeroIP == RENDEZVOUS_IP_TEMPLATE_VALUE {
+			return ""
+		}
 	}
 
 	return nodeZeroIP

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -42,17 +42,13 @@ func main() {
 // then this function reads /etc/assisted/rendezvous-host.env
 // for the value..
 func getRendezvousIP() string {
-	nodeZeroIP := os.Getenv("NODE_ZERO_IP")
-
-	if nodeZeroIP == "" {
-		envMap, err := godotenv.Read(ui.RENDEZVOUS_HOST_ENV_PATH)
-		if err != nil {
-			return ""
-		}
-		nodeZeroIP = envMap["NODE_ZERO_IP"]
-		if nodeZeroIP == RENDEZVOUS_IP_TEMPLATE_VALUE {
-			return ""
-		}
+	envMap, err := godotenv.Read(ui.RENDEZVOUS_HOST_ENV_PATH)
+	if err != nil {
+		return ""
+	}
+	nodeZeroIP := envMap["NODE_ZERO_IP"]
+	if nodeZeroIP == RENDEZVOUS_IP_TEMPLATE_VALUE {
+		return ""
 	}
 
 	return nodeZeroIP

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"log"
 
 	"github.com/joho/godotenv"
 
@@ -33,7 +32,6 @@ func main() {
 	agent_tui.App(nil, getRendezvousIP(), config)
 }
 
-
 // The rendezvous IP address can be passed into AGENT_TUI
 // through the NODE_ZERO_IP environment variable.
 // If NODE_ZERO_IP is unset through the environment variable,
@@ -45,7 +43,7 @@ func getRendezvousIP() string {
 	if nodeZeroIP == "" {
 		envMap, err := godotenv.Read(ui.RENDEZVOUS_HOST_ENV_PATH)
 		if err != nil {
-			log.Fatalf("Could not read %s", ui.RENDEZVOUS_HOST_ENV_PATH)
+			return ""
 		}
 		nodeZeroIP = envMap["NODE_ZERO_IP"]
 	}

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	CONFIGURE_NETWORK_LABEL string = "Configure Networking"
-	RELEASE_IMAGE_LABEL     string = "Release Image"
-	CONFIGURE_BUTTON        string = "<Configure network>"
-	QUIT_BUTTON             string = "<Quit>"
-	PAGE_CHECKSCREEN        string = "checkScreen"
+	CONFIGURE_NETWORK_LABEL   string = "Configure Networking"
+	RELEASE_IMAGE_LABEL       string = "Release Image"
+	CONFIGURE_BUTTON          string = "<Configure network>"
+	QUIT_BUTTON               string = "<Quit>"
+	PAGE_CHECKSCREEN          string = "checkScreen"
 
 	mainFlexHeight            = 10
 	mainFlexWithDetailsHeight = 30
@@ -127,11 +127,11 @@ func (u *UI) createCheckPage(config checks.Config) {
 	u.details.SetBackgroundColor(newt.ColorGray)
 	u.details.SetTitleColor(newt.ColorBlack)
 
-	u.form = tview.NewForm()
-	u.form.SetBorder(false)
-	u.form.SetBackgroundColor(newt.ColorGray)
-	u.form.SetButtonsAlign(tview.AlignCenter)
-	u.form.AddButton(CONFIGURE_BUTTON, func() {
+	u.netConfigForm = tview.NewForm()
+	u.netConfigForm.SetBorder(false)
+	u.netConfigForm.SetBackgroundColor(newt.ColorGray)
+	u.netConfigForm.SetButtonsAlign(tview.AlignCenter)
+	u.netConfigForm.AddButton(CONFIGURE_BUTTON, func() {
 		if err := u.ShowNMTUI(); err != nil {
 			errorDialog := tview.NewModal().
 				SetBackgroundColor(newt.ColorBlack).
@@ -143,18 +143,18 @@ func (u *UI) createCheckPage(config checks.Config) {
 			u.pages.AddPage("error", errorDialog, false, true)
 		}
 	})
-	u.form.AddButton(QUIT_BUTTON, func() {
+	u.netConfigForm.AddButton(QUIT_BUTTON, func() {
 		u.app.Stop()
 	})
-	u.form.SetButtonActivatedStyle(tcell.StyleDefault.Background(newt.ColorRed).
+	u.netConfigForm.SetButtonActivatedStyle(tcell.StyleDefault.Background(newt.ColorRed).
 		Foreground(newt.ColorGray))
-	u.form.SetButtonStyle(tcell.StyleDefault.Background(newt.ColorGray).
+	u.netConfigForm.SetButtonStyle(tcell.StyleDefault.Background(newt.ColorGray).
 		Foreground(newt.ColorBlack))
 
 	u.mainFlex = tview.NewFlex().
 		SetDirection(tview.FlexRow).
 		AddItem(u.primaryCheck, 5, 0, false).
-		AddItem(u.form, 3, 0, false)
+		AddItem(u.netConfigForm, 3, 0, false)
 	u.mainFlex.SetTitle("  Agent installer network boot setup  ").
 		SetTitleColor(newt.ColorRed).
 		SetBorder(true).
@@ -168,8 +168,8 @@ func (u *UI) createCheckPage(config checks.Config) {
 
 	// Initially, only the form buttons can receive the focus
 	u.focusableItems = []tview.Primitive{
-		u.form.GetButton(0),
-		u.form.GetButton(1),
+		u.netConfigForm.GetButton(0),
+		u.netConfigForm.GetButton(1),
 	}
 	// Allow the user to cycle the focus only over the configured items
 	u.mainFlex.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
@@ -203,7 +203,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 
 	u.pages.SetBackgroundColor(newt.ColorBlue)
 	u.pages.AddPage(PAGE_CHECKSCREEN, flex, true, true)
-	u.app.SetRoot(u.pages, true).SetFocus(u.form)
+	u.app.SetRoot(u.pages, true).SetFocus(u.netConfigForm)
 }
 
 func (u *UI) additionalChecksVisible() bool {
@@ -235,10 +235,10 @@ func (u *UI) ShowAdditionalChecks() {
 	}
 
 	u.mainFlex.
-		RemoveItem(u.form).
+		RemoveItem(u.netConfigForm).
 		AddItem(u.checks, 5, 0, false).
 		AddItem(u.details, 15, 0, false).
-		AddItem(u.form, 3, 0, false)
+		AddItem(u.netConfigForm, 3, 0, false)
 	u.innerFlex.ResizeItem(u.mainFlex, mainFlexWithDetailsHeight, 0)
 
 	// Details can be focused again

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -138,7 +138,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 				SetText(err.Error()).
 				AddButtons([]string{"Ok"}).
 				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-					u.returnFocusToChecks()
+					u.setFocusToChecks()
 				})
 			u.pages.AddPage("error", errorDialog, false, true)
 		}

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	CONFIGURE_NETWORK_LABEL   string = "Configure Networking"
-	RELEASE_IMAGE_LABEL       string = "Release Image"
-	CONFIGURE_BUTTON          string = "<Configure network>"
-	QUIT_BUTTON               string = "<Quit>"
-	PAGE_CHECKSCREEN          string = "checkScreen"
+	CONFIGURE_NETWORK_LABEL string = "Configure Networking"
+	RELEASE_IMAGE_LABEL     string = "Release Image"
+	CONFIGURE_BUTTON        string = "<Configure network>"
+	QUIT_BUTTON             string = "<Quit>"
+	PAGE_CHECKSCREEN        string = "checkScreen"
 
 	mainFlexHeight            = 10
 	mainFlexWithDetailsHeight = 30

--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -132,16 +132,7 @@ func (u *UI) createCheckPage(config checks.Config) {
 	u.netConfigForm.SetBackgroundColor(newt.ColorGray)
 	u.netConfigForm.SetButtonsAlign(tview.AlignCenter)
 	u.netConfigForm.AddButton(CONFIGURE_BUTTON, func() {
-		if err := u.ShowNMTUI(); err != nil {
-			errorDialog := tview.NewModal().
-				SetBackgroundColor(newt.ColorBlack).
-				SetText(err.Error()).
-				AddButtons([]string{"Ok"}).
-				SetDoneFunc(func(buttonIndex int, buttonLabel string) {
-					u.setFocusToChecks()
-				})
-			u.pages.AddPage("error", errorDialog, false, true)
-		}
+		u.showNMTUIWithErrorDialog(u.setFocusToChecks)
 	})
 	u.netConfigForm.AddButton(QUIT_BUTTON, func() {
 		u.app.Stop()

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -9,8 +9,9 @@ type Controller struct {
 	ui      *UI
 	channel chan checks.CheckResult
 
-	checks map[string]checks.CheckResult
-	state  bool
+	checks          map[string]checks.CheckResult
+	state           bool
+	rendezvousIPSet bool
 }
 
 func NewController(ui *UI) *Controller {
@@ -39,9 +40,12 @@ func (c *Controller) receivedPrimaryCheck(numChecks int) bool {
 	return found
 }
 
-func (c *Controller) Init(numChecks int) {
-
+func (c *Controller) Init(numChecks int, rendezvousIP string) {
 	c.ui.ShowSplashScreen()
+
+	if rendezvousIP == "" {
+		c.ui.setFocusToRendezvousIP()
+	}
 
 	go func() {
 		for {
@@ -57,6 +61,12 @@ func (c *Controller) Init(numChecks int) {
 			// When nmtui is shown the UI is suspended, so
 			// let's skip any update
 			if c.ui.IsNMTuiActive() {
+				continue
+			}
+
+			// Checks are suspended if rendezvous IP form
+			// is active
+			if c.ui.IsRendezvousIPFormActive() {
 				continue
 			}
 

--- a/tools/agent_tui/ui/controller.go
+++ b/tools/agent_tui/ui/controller.go
@@ -45,6 +45,8 @@ func (c *Controller) Init(numChecks int, rendezvousIP string) {
 
 	if rendezvousIP == "" {
 		c.ui.setFocusToRendezvousIP()
+	} else {
+		c.ui.setFocusToChecks()
 	}
 
 	go func() {
@@ -83,7 +85,7 @@ func (c *Controller) Init(numChecks int, rendezvousIP string) {
 					if c.state {
 						c.ui.ShowTimeoutDialog()
 					} else {
-						c.ui.returnFocusToChecks()
+						c.ui.setFocusToChecks()
 					}
 				})
 				continue

--- a/tools/agent_tui/ui/invalid_ip_address_modal.go
+++ b/tools/agent_tui/ui/invalid_ip_address_modal.go
@@ -17,8 +17,6 @@ const (
 // to pages. The rendezvousIPForm does that when it validates the IP
 // address entered.
 func (u *UI) createErrorModal() {
-	// view is the modal asking the user if they would still
-	// like to change their network configuration.
 	u.errorModal = tview.NewModal().
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			if buttonLabel == OK_BUTTON {
@@ -35,12 +33,10 @@ func (u *UI) createErrorModal() {
 	userPromptButtons := []string{OK_BUTTON}
 	u.errorModal.AddButtons(userPromptButtons)
 
-	//u.invalidIPAddressModal.SetText(invalidIPText)
 	u.pages.AddPage(PAGE_ERROR_DIALOG, u.errorModal, true, false)
 }
 
 func (u *UI) ShowErrorDialog(errorText string) {
-	//u.setIsTimeoutDialogActive(true)
 	u.errorModal.SetText(errorText)
 	u.app.SetFocus(u.errorModal)
 	u.pages.ShowPage(PAGE_ERROR_DIALOG)

--- a/tools/agent_tui/ui/invalid_ip_address_modal.go
+++ b/tools/agent_tui/ui/invalid_ip_address_modal.go
@@ -1,0 +1,47 @@
+package ui
+
+import (
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+const (
+	OK_BUTTON         string = "<Ok>"
+	PAGE_ERROR_DIALOG        = "invalidIPAddress"
+
+	invalidIPText         = "The IP address %s is not a valid IPv4 or IPv6 address"
+	saveRendezvousIPError = "Error saving rendezvous IP address to /etc/assisted/rendezvous-host.env: %v"
+)
+
+// Creates the invalid IP address modal but does not add the modal
+// to pages. The rendezvousIPForm does that when it validates the IP
+// address entered.
+func (u *UI) createErrorModal() {
+	// view is the modal asking the user if they would still
+	// like to change their network configuration.
+	u.errorModal = tview.NewModal().
+		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+			if buttonLabel == OK_BUTTON {
+				u.setFocusToRendezvousIP()
+			}
+		}).
+		SetBackgroundColor(newt.ColorBlack)
+	u.errorModal.
+		SetBorderColor(newt.ColorBlack).
+		SetBorder(true)
+	u.errorModal.
+		SetButtonBackgroundColor(newt.ColorGray).
+		SetButtonTextColor(newt.ColorRed)
+	userPromptButtons := []string{OK_BUTTON}
+	u.errorModal.AddButtons(userPromptButtons)
+
+	//u.invalidIPAddressModal.SetText(invalidIPText)
+	u.pages.AddPage(PAGE_ERROR_DIALOG, u.errorModal, true, false)
+}
+
+func (u *UI) ShowErrorDialog(errorText string) {
+	//u.setIsTimeoutDialogActive(true)
+	u.errorModal.SetText(errorText)
+	u.app.SetFocus(u.errorModal)
+	u.pages.ShowPage(PAGE_ERROR_DIALOG)
+}

--- a/tools/agent_tui/ui/netstate_treeview.go
+++ b/tools/agent_tui/ui/netstate_treeview.go
@@ -76,7 +76,7 @@ func (u *UI) TreeView(netState net.NetState) (*tview.TreeView, error) {
 		SetCurrentNode(root).SetDoneFunc(
 		func(key tcell.Key) {
 			u.pages.RemovePage("netstate")
-			u.returnFocusToChecks()
+			u.setFocusToChecks()
 		})
 
 	tree.SetTitle("Network Status").
@@ -89,7 +89,7 @@ func (u *UI) TreeView(netState net.NetState) (*tview.TreeView, error) {
 		func(event *tcell.EventKey) *tcell.EventKey {
 			if event.Rune() == 'q' {
 				u.pages.RemovePage("netstate")
-				u.returnFocusToChecks()
+				u.setFocusToChecks()
 			}
 			return event
 		})

--- a/tools/agent_tui/ui/nmtui.go
+++ b/tools/agent_tui/ui/nmtui.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/nmstate/nmstate/rust/src/go/nmstate/v2"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/net"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
 )
 
 func (u *UI) ShowNMTUI() error {
@@ -43,4 +45,18 @@ func (u *UI) ShowNMTUI() error {
 	u.pages.AddPage("netstate", netStatePage, true, true)
 
 	return nil
+}
+
+func (u *UI) showNMTUIWithErrorDialog(doneFunc func()) {
+	if err := u.ShowNMTUI(); err != nil {
+		errorDialog := tview.NewModal().
+			SetBackgroundColor(newt.ColorBlack).
+			SetText(err.Error()).
+			AddButtons([]string{"Ok"}).
+			SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+				doneFunc()
+			})
+		u.pages.AddPage("error", errorDialog, false, true)
+	}
+	doneFunc()
 }

--- a/tools/agent_tui/ui/rendezvous_ip.go
+++ b/tools/agent_tui/ui/rendezvous_ip.go
@@ -23,13 +23,6 @@ const (
 )
 
 func (u *UI) createRendezvousIPPage(config checks.Config) {
-	primaryCheck := tview.NewTable()
-	primaryCheck.SetBorder(true)
-	primaryCheck.SetTitle("  Current Host IPs  ")
-	primaryCheck.SetBorderColor(newt.ColorBlack)
-	primaryCheck.SetBackgroundColor(newt.ColorGray)
-	primaryCheck.SetTitleColor(newt.ColorBlack)
-
 	u.rendezvousIPForm = tview.NewForm()
 	u.rendezvousIPForm.SetBorder(false)
 	u.rendezvousIPForm.SetBackgroundColor(newt.ColorGray)
@@ -132,7 +125,7 @@ func (u *UI) hostIPAddresses() []string {
 	ipv6 := []string{}
 	for _, addr := range addrs {
 		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil {
+			if ipnet.IP.To4() != nil && !ipnet.IP.IsLinkLocalUnicast() {
 				ipv4 = append(ipv4, ipnet.IP.String())
 			} else if ipnet.IP.To16() != nil {
 				ipv6 = append(ipv6, ipnet.IP.String())

--- a/tools/agent_tui/ui/rendezvous_ip.go
+++ b/tools/agent_tui/ui/rendezvous_ip.go
@@ -13,9 +13,9 @@ import (
 const (
 	PAGE_RENDEZVOUS_IP          = "rendezvousIPScreen"
 	PAGE_SET_NODE_AS_RENDEZVOUS = "setNodeAsRendezvousScreen"
-	FIELD_ENTER_RENDEZVOUS_IP   = "Rendezvous node IP"
+	FIELD_ENTER_RENDEZVOUS_IP   = "Rendezvous IP"
 	SAVE_RENDEZVOUS_IP_BUTTON   = "<Save Rendezvous IP>"
-	SELECT_IP_ADDRESS_BUTTON    = "<Choose one of this node's IPs to be the Rendezvous node IP>"
+	SELECT_IP_ADDRESS_BUTTON    = "<Designate this node as the Rendezvous node by selecting one of its IPs>"
 	RENDEZVOUS_HOST_ENV_PATH    = "/etc/assisted/rendezvous-host.env"
 )
 
@@ -36,17 +36,12 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 	u.rendezvousIPForm.SetBorder(false)
 	u.rendezvousIPForm.SetButtonsAlign(tview.AlignCenter)
 
-	rendezvousIPFormDescription := "If you have already designated a node to be the rendezvous node, enter its IP address in the field below."
+	rendezvousIPFormDescription := "Enter the Rendezvous node's IP address if one has been designated."
 	rendezvousTextFlex := u.createTextFlex(rendezvousIPFormDescription)
-	rendezvousTextNumRows := 5
+	rendezvousTextNumRows := 3
 
 	u.rendezvousIPForm.AddInputField(FIELD_ENTER_RENDEZVOUS_IP, "", 55, nil, nil)
 	u.rendezvousIPForm.SetFieldTextColor(newt.ColorGray)
-
-	list := tview.NewList()
-	for i, ip := range u.hostIPAddresses() {
-		list.AddItem(ip, "", rune(i), nil)
-	}
 
 	u.rendezvousIPForm.AddButton(SAVE_RENDEZVOUS_IP_BUTTON, func() {
 		// save rendezvous IP address and switch to checks page
@@ -58,7 +53,7 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 			}
 			u.ShowErrorDialog(fmt.Sprintf(invalidIPText, ipAddress))
 		} else {
-			err := saveRendezvousIPAddress(ipAddress)
+			err := u.saveRendezvousIPAddress(ipAddress)
 			if err != nil {
 				u.ShowErrorDialog(fmt.Sprintf(saveRendezvousIPError, err.Error()))
 			} else {
@@ -71,9 +66,9 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 	u.rendezvousIPForm.SetButtonStyle(tcell.StyleDefault.Background(newt.ColorGray).
 		Foreground(newt.ColorBlack))
 
-	selectFormDescription := "If the rendezvous node has not been designated, this node can be designated as the rendezvous node by selecting one of its IP addresses to be the rendezvous node IP."
+	selectFormDescription := "----------------------------------- or ------------------------------------\n\n"
 	selectTextFlex := u.createTextFlex(selectFormDescription)
-	selectTextNumRows := 5
+	selectTextNumRows := 3
 
 	u.selectIPForm = tview.NewForm()
 	u.selectIPForm.SetBorder(false)
@@ -135,79 +130,9 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 	u.pages.AddPage(PAGE_RENDEZVOUS_IP, flex, true, true)
 }
 
-func (u *UI) createSelectHostIPPage() {
-	u.selectIPList = tview.NewList()
-	backOption := "<Back>"
-	options := append(u.hostIPAddresses(), backOption)
-	for _, ip := range options {
-		u.selectIPList.AddItem(ip, "", rune(0), func() {
-			if ip == backOption {
-				u.setFocusToRendezvousIP()
-			} else {
-				err := saveRendezvousIPAddress(ip)
-				if err != nil {
-					u.ShowErrorDialog(fmt.Sprintf(saveRendezvousIPError, err.Error()))
-				} else {
-					u.showRendezvousIPSaveSuccessModal(ip)
-				}
-			}
-		})
-	}
-	u.selectIPList.SetSelectedBackgroundColor(newt.ColorRed)
-	u.selectIPList.SetSelectedTextColor(newt.ColorGray)
-	u.selectIPList.ShowSecondaryText(false)
-	u.selectIPList.SetBorderPadding(0, 0, 2, 2)
-
-	descriptionText := fmt.Sprintf("Select an IP address from this node to be the Rendezvous node IP.")
-	textFlex := u.createTextFlex(descriptionText)
-	textRows := 4
-
-	mainFlex := tview.NewFlex().
-		SetDirection(tview.FlexRow).
-		AddItem(textFlex, textRows, 0, false).
-		AddItem(u.selectIPList, len(options)+1, 0, false)
-	mainFlex.SetTitle("  Select an IP address to be the Rendezvous node IP  ").
-		SetTitleColor(newt.ColorRed).
-		SetBorder(true)
-
-	innerFlex := tview.NewFlex().SetDirection(tview.FlexRow).
-		AddItem(nil, 0, 1, false).
-		AddItem(mainFlex, len(options)+3+textRows, 0, false).
-		AddItem(nil, 0, 1, false)
-
-	width := 80
-	flex := tview.NewFlex().
-		AddItem(nil, 0, 1, false).
-		AddItem(innerFlex, width, 1, false).
-		AddItem(nil, 0, 1, false)
-
-	u.pages.AddPage(PAGE_SET_NODE_AS_RENDEZVOUS, flex, true, true)
-}
-
 func validateIP(ipAddress string) string {
 	if net.ParseIP(ipAddress) == nil {
 		return fmt.Sprintf("%s is not a valid IP address", ipAddress)
 	}
 	return ""
-}
-
-func (u *UI) hostIPAddresses() []string {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		u.logger.Errorf("Could not fetch host IPs: %v", err)
-	}
-	ipv4 := []string{}
-	ipv6 := []string{}
-	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if ipnet.IP.To4() != nil && !ipnet.IP.IsLinkLocalUnicast() {
-				ipv4 = append(ipv4, ipnet.IP.String())
-			} else if ipnet.IP.To16() != nil {
-				ipv6 = append(ipv6, ipnet.IP.String())
-			}
-		}
-	}
-	u.logger.Infof("current host IPv4 addresses: %v", ipv4)
-	u.logger.Infof("current host IPv6 addresses: %v", ipv6)
-	return append(ipv4, ipv6...)
 }

--- a/tools/agent_tui/ui/rendezvous_ip.go
+++ b/tools/agent_tui/ui/rendezvous_ip.go
@@ -57,7 +57,7 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 			if err != nil {
 				u.ShowErrorDialog(fmt.Sprintf(saveRendezvousIPError, err.Error()))
 			} else {
-				u.showRendezvousIPSaveSuccessModal(ipAddress)
+				u.showRendezvousIPSaveSuccessModal(ipAddress, u.setFocusToRendezvousIP)
 			}
 		}
 	})

--- a/tools/agent_tui/ui/rendezvous_ip.go
+++ b/tools/agent_tui/ui/rendezvous_ip.go
@@ -18,6 +18,7 @@ const (
 	FIELD_SET_IP              = "Use Host IP as Rendezvous"
 	FIELD_RENDEZVOUS_HOST_IP  = "Rendezvous Host IP"
 	SAVE_RENDEZVOUS_IP_BUTTON = "<Save Rendezvous IP Address>"
+	RENDEZVOUS_HOST_ENV_PATH  = "/etc/assisted/rendezvous-host.env"
 )
 
 func (u *UI) createRendezvousIPPage(config checks.Config) {
@@ -39,7 +40,7 @@ func (u *UI) createRendezvousIPPage(config checks.Config) {
 		if checked && len(u.hostIPAddresses()) > 0 {
 			field.SetText(u.hostIPAddresses()[0])
 		} else {
-			// unchecked, reset rendezvou IP field
+			// unchecked, reset rendezvous IP field
 			field.SetText("")
 		}
 	})
@@ -143,7 +144,7 @@ func (u *UI) hostIPAddresses() []string {
 }
 
 func saveIPAddress(ipAddress string) error {
-	cmd := exec.Command("sed", "-i", fmt.Sprintf("s/^NODE_ZERO_IP=.*/NODE_ZERO_IP=%s/", ipAddress), "/etc/assisted/rendezvous-host.env")
+	cmd := exec.Command("sed", "-i", fmt.Sprintf("s/^NODE_ZERO_IP=.*/NODE_ZERO_IP=%s/", ipAddress), RENDEZVOUS_HOST_ENV_PATH)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tools/agent_tui/ui/rendezvous_ip.go
+++ b/tools/agent_tui/ui/rendezvous_ip.go
@@ -1,0 +1,142 @@
+package ui
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+const (
+	PAGE_RENDEZVOUS_IP        = "rendezvousIPScreen"
+	FIELD_CURRENT_HOST_IP     = "Current Host IPs"
+	FIELD_RENDEZVOUS_HOST_IP  = "Rendezvous Host IP"
+	SAVE_RENDEZVOUS_IP_BUTTON = "<Save Rendezvous IP Address>"
+)
+
+func (u *UI) createRendezvousIPPage(config checks.Config) {
+	primaryCheck := tview.NewTable()
+	primaryCheck.SetBorder(true)
+	primaryCheck.SetTitle("  Current Host IPs  ")
+	primaryCheck.SetBorderColor(newt.ColorBlack)
+	primaryCheck.SetBackgroundColor(newt.ColorGray)
+	primaryCheck.SetTitleColor(newt.ColorBlack)
+
+	u.rendezvousIPForm = tview.NewForm()
+	u.rendezvousIPForm.SetBorder(false)
+	u.rendezvousIPForm.SetBackgroundColor(newt.ColorGray)
+	u.rendezvousIPForm.SetButtonsAlign(tview.AlignCenter)
+	u.rendezvousIPForm.AddInputField(FIELD_CURRENT_HOST_IP, strings.Join(u.hostIPAddresses()[:2], ","), 55, nil, nil)
+	u.rendezvousIPForm.AddInputField(FIELD_RENDEZVOUS_HOST_IP, "", 55, nil, nil)
+	u.rendezvousIPForm.AddButton(SAVE_RENDEZVOUS_IP_BUTTON, func() {
+		// save rendezvous IP address and switch to checks page
+		ipAddress := u.rendezvousIPForm.GetFormItemByLabel(FIELD_RENDEZVOUS_HOST_IP).(*tview.InputField).GetText()
+		validationError := validateIP(ipAddress)
+		if validationError != "" {
+			u.ShowErrorDialog(fmt.Sprintf(invalidIPText, ipAddress))
+		} else {
+			err := saveIPAddress(ipAddress)
+			if err != nil {
+				u.ShowErrorDialog(fmt.Sprintf(saveRendezvousIPError, err.Error()))
+			} else {
+				// set focus to checks page and let controller know rendezvousIP is set
+				u.setIsRendezousIPFormActive(false)
+				u.returnFocusToChecks()
+			}
+		}
+	})
+	u.rendezvousIPForm.SetButtonActivatedStyle(tcell.StyleDefault.Background(newt.ColorRed).
+		Foreground(newt.ColorGray))
+	u.rendezvousIPForm.SetButtonStyle(tcell.StyleDefault.Background(newt.ColorGray).
+		Foreground(newt.ColorBlack))
+
+	mainFlex := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(u.rendezvousIPForm, 8, 0, false)
+	mainFlex.SetTitle("  Rendezvous Host IP Setup  ").
+		SetTitleColor(newt.ColorRed).
+		SetBorder(true).
+		SetBackgroundColor(newt.ColorGray).
+		SetBorderColor(tcell.ColorBlack)
+
+	innerFlex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(mainFlex, mainFlexHeight, 0, false).
+		AddItem(nil, 0, 1, false)
+
+	// Allow the user to cycle the focus only over the configured items
+	mainFlex.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch event.Key() {
+		case tcell.KeyTab, tcell.KeyUp:
+			u.focusedItem++
+			if u.focusedItem > len(u.focusableItems)-1 {
+				u.focusedItem = 0
+			}
+
+		case tcell.KeyBacktab, tcell.KeyDown:
+			u.focusedItem--
+			if u.focusedItem < 0 {
+				u.focusedItem = len(u.focusableItems) - 1
+			}
+
+		default:
+			// forward the event to the default handler
+			return event
+		}
+
+		u.app.SetFocus(u.focusableItems[u.focusedItem])
+		return nil
+	})
+
+	width := 80
+	flex := tview.NewFlex().
+		AddItem(nil, 0, 1, false).
+		AddItem(innerFlex, width, 1, false).
+		AddItem(nil, 0, 1, false)
+
+	u.pages.SetBackgroundColor(newt.ColorBlue)
+	u.pages.AddPage(PAGE_RENDEZVOUS_IP, flex, true, true)
+}
+
+func validateIP(ipAddress string) string {
+	if net.ParseIP(ipAddress) == nil {
+		return fmt.Sprintf("%s is not a valid IP address", ipAddress)
+	}
+	return ""
+}
+
+func (u *UI) hostIPAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		u.logger.Errorf("Could not fetch host IPs: err", err)
+	}
+	ipv4 := []string{}
+	ipv6 := []string{}
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil {
+				ipv4 = append(ipv4, ipnet.IP.String())
+			} else if ipnet.IP.To16() != nil {
+				ipv6 = append(ipv6, ipnet.IP.String())
+			}
+		}
+	}
+	u.logger.Infof("current host IPv4 addresses: %v", ipv4)
+	u.logger.Infof("current host IPv6 addresses: %v", ipv6)
+	return append(ipv4, ipv6...)
+}
+
+func saveIPAddress(ipAddress string) error {
+	cmd := exec.Command("sed", "-i", fmt.Sprintf("s/^NODE_ZERO_IP=.*/NODE_ZERO_IP=%s/", ipAddress), "/etc/assisted/rendezvous-host.env")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("sed command failed: %v out: %v", err, string(output))
+	}
+	return nil
+}

--- a/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
@@ -9,15 +9,14 @@ import (
 
 const (
 	PAGE_RENDEZVOUS_IP_SAVE_SUCCESS string = "rendezvousIPSaveSuccessPage"
-	CONTINUE_INSTALLATION_BUTTION = "<Continue with installation>"
-	BACK_BUTTON = "<Back>"
+	CONTINUE_INSTALLATION_BUTTION          = "<Continue with installation>"
+	BACK_BUTTON                            = "<Back>"
 
 	successText    = "Successfully saved %s as the Rendezvous node IP. "
 	otherNodesText = "Enter %s as the Rendezvous node IP on the other nodes that will form the cluster."
-	
 )
 
-func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string) {
+func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string, focusForBackButton func()) {
 	// view is the modal asking the user if they would still
 	// like to change their network configuration.
 	u.rendezvousIPSaveSuccessModal = tview.NewModal()
@@ -26,7 +25,7 @@ func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string) {
 			u.app.Stop()
 		}
 		if buttonLabel == BACK_BUTTON {
-			u.setFocusToSelectIP()
+			focusForBackButton()
 		}
 	})
 	u.rendezvousIPSaveSuccessModal.SetBackgroundColor(newt.ColorGray) // ContrastBackgroundColor, default is newt.ColorBlue

--- a/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
@@ -1,0 +1,58 @@
+package ui
+
+import (
+	"fmt"
+
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+const (
+	PAGE_RENDEZVOUS_IP_SAVE_SUCCESS string = "rendezvousIPSaveSuccessPage"
+	CONTINUE_INSTALLATION_BUTTION = "<Continue with installation>"
+
+	successText    = "Successfully saved %s as the Rendezvous node IP. "
+	otherNodesText = "Enter %s as the Rendezvous node IP on the other nodes that will form the cluster."
+	
+)
+
+func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string) {
+	// view is the modal asking the user if they would still
+	// like to change their network configuration.
+	u.rendezvousIPSaveSuccessModal = tview.NewModal()
+	u.rendezvousIPSaveSuccessModal.SetDoneFunc(func(buttonIndex int, buttonLabel string) {
+		if buttonLabel == CONTINUE_INSTALLATION_BUTTION {
+			u.app.Stop()
+		}
+	})
+	u.rendezvousIPSaveSuccessModal.SetBackgroundColor(newt.ColorGray) // ContrastBackgroundColor, default is newt.ColorBlue
+	u.rendezvousIPSaveSuccessModal.SetBorder(true)
+	u.rendezvousIPSaveSuccessModal.
+		SetButtonBackgroundColor(newt.ColorGray).
+		SetButtonTextColor(newt.ColorRed)
+	userPromptButtons := []string{CONTINUE_INSTALLATION_BUTTION}
+	u.rendezvousIPSaveSuccessModal.AddButtons(userPromptButtons)
+
+	text := successText
+	if contains(u.hostIPAddresses(), savedIP) {
+		// This node was designated as the Rendezvous node.
+		// Prompt the user to enter the IP on other nodes.
+		text += otherNodesText
+		u.rendezvousIPSaveSuccessModal.SetText(fmt.Sprintf(text, savedIP, savedIP))
+	} else {
+		u.rendezvousIPSaveSuccessModal.SetText(fmt.Sprintf(text, savedIP))
+	}
+
+	u.pages.AddPage(PAGE_RENDEZVOUS_IP_SAVE_SUCCESS, u.rendezvousIPSaveSuccessModal, true, false)
+	u.app.SetFocus(u.rendezvousIPSaveSuccessModal)
+	u.pages.ShowPage(PAGE_RENDEZVOUS_IP_SAVE_SUCCESS)
+}
+
+func contains(arr []string, str string) bool {
+	for _, element := range arr {
+		if element == str {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
@@ -10,6 +10,7 @@ import (
 const (
 	PAGE_RENDEZVOUS_IP_SAVE_SUCCESS string = "rendezvousIPSaveSuccessPage"
 	CONTINUE_INSTALLATION_BUTTION = "<Continue with installation>"
+	BACK_BUTTON = "<Back>"
 
 	successText    = "Successfully saved %s as the Rendezvous node IP. "
 	otherNodesText = "Enter %s as the Rendezvous node IP on the other nodes that will form the cluster."
@@ -24,13 +25,16 @@ func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string) {
 		if buttonLabel == CONTINUE_INSTALLATION_BUTTION {
 			u.app.Stop()
 		}
+		if buttonLabel == BACK_BUTTON {
+			u.setFocusToSelectIP()
+		}
 	})
 	u.rendezvousIPSaveSuccessModal.SetBackgroundColor(newt.ColorGray) // ContrastBackgroundColor, default is newt.ColorBlue
 	u.rendezvousIPSaveSuccessModal.SetBorder(true)
 	u.rendezvousIPSaveSuccessModal.
 		SetButtonBackgroundColor(newt.ColorGray).
 		SetButtonTextColor(newt.ColorRed)
-	userPromptButtons := []string{CONTINUE_INSTALLATION_BUTTION}
+	userPromptButtons := []string{CONTINUE_INSTALLATION_BUTTION, BACK_BUTTON}
 	u.rendezvousIPSaveSuccessModal.AddButtons(userPromptButtons)
 
 	text := successText

--- a/tools/agent_tui/ui/rendezvous_ip_select.go
+++ b/tools/agent_tui/ui/rendezvous_ip_select.go
@@ -1,0 +1,93 @@
+package ui
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/openshift/agent-installer-utils/tools/agent_tui/newt"
+	"github.com/rivo/tview"
+)
+
+func (u *UI) createSelectHostIPPage() {
+	u.selectIPList = tview.NewList()
+	u.refreshSelectIPList()
+	u.selectIPList.SetSelectedBackgroundColor(newt.ColorRed)
+	u.selectIPList.SetSelectedTextColor(newt.ColorGray)
+	u.selectIPList.ShowSecondaryText(false)
+	u.selectIPList.SetBorderPadding(0, 0, 2, 2)
+
+	descriptionText := fmt.Sprintf("Select an IP address from this node to be the Rendezvous node IP.")
+	textFlex := u.createTextFlex(descriptionText)
+	textRows := 3
+
+	mainFlex := tview.NewFlex().
+		SetDirection(tview.FlexRow).
+		AddItem(textFlex, textRows, 0, false).
+		AddItem(u.selectIPList, u.selectIPList.GetItemCount()+1, 0, false)
+	mainFlex.SetTitle("  Rendezvous Node IP Selection  ").
+		SetTitleColor(newt.ColorRed).
+		SetBorder(true)
+
+	innerFlex := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(mainFlex, u.selectIPList.GetItemCount()+3+textRows, 0, false).
+		AddItem(nil, 0, 1, false)
+
+	width := 80
+	flex := tview.NewFlex().
+		AddItem(nil, 0, 1, false).
+		AddItem(innerFlex, width, 1, false).
+		AddItem(nil, 0, 1, false)
+
+	u.pages.AddPage(PAGE_SET_NODE_AS_RENDEZVOUS, flex, true, true)
+}
+
+func (u *UI) hostIPAddresses() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		u.logger.Errorf("Could not fetch host IPs: %v", err)
+	}
+	ipv4 := []string{}
+	ipv6 := []string{}
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+			if ipnet.IP.To4() != nil && !ipnet.IP.IsLinkLocalUnicast() {
+				ipv4 = append(ipv4, ipnet.IP.String())
+			} else if ipnet.IP.To16() != nil {
+				ipv6 = append(ipv6, ipnet.IP.String())
+			}
+		}
+	}
+	u.logger.Infof("current host IPv4 addresses: %v", ipv4)
+	u.logger.Infof("current host IPv6 addresses: %v", ipv6)
+	return append(ipv4, ipv6...)
+}
+
+func (u *UI) refreshSelectIPList() {
+	listSize := u.selectIPList.GetItemCount()
+	for i := 0; i < listSize; i++ {
+		u.selectIPList.RemoveItem(i)
+	}
+	backOption := "<Back>"
+	configureNetworkOption := "<Configure Network>"
+	options := append(u.hostIPAddresses(), backOption, configureNetworkOption)
+	for _, selected := range options {
+		u.selectIPList.AddItem(selected, "", rune(0), func() {
+			if selected == backOption {
+				u.setFocusToRendezvousIP()
+			} else if selected == configureNetworkOption {
+				u.showNMTUIWithErrorDialog(func() {
+					u.refreshSelectIPList()
+					u.setFocusToSelectIP()
+				})
+			} else {
+				err := u.saveRendezvousIPAddress(selected)
+				if err != nil {
+					u.ShowErrorDialog(fmt.Sprintf(saveRendezvousIPError, err.Error()))
+				} else {
+					u.showRendezvousIPSaveSuccessModal(selected, u.setFocusToSelectIP)
+				}
+			}
+		})
+	}
+}

--- a/tools/agent_tui/ui/rendezvous_ip_template.go
+++ b/tools/agent_tui/ui/rendezvous_ip_template.go
@@ -10,7 +10,7 @@ type rendezvousHostEnvTemplateData struct {
 	RendezvousIP string
 }
 
-func saveRendezvousIPAddress(ipAddress string) error {
+func (u *UI) saveRendezvousIPAddress(ipAddress string) error {
 	templateData := &rendezvousHostEnvTemplateData{
 		RendezvousIP: ipAddress,
 	}
@@ -18,6 +18,8 @@ func saveRendezvousIPAddress(ipAddress string) error {
 	if err != nil {
 		return err
 	}
+
+	u.logger.Infof("Saved %s as Rendezvous IP", ipAddress)
 
 	return nil
 }

--- a/tools/agent_tui/ui/rendezvous_ip_template.go
+++ b/tools/agent_tui/ui/rendezvous_ip_template.go
@@ -2,9 +2,7 @@ package ui
 
 import (
 	"bytes"
-	"fmt"
 	"os"
-	"strings"
 	"text/template"
 )
 
@@ -13,29 +11,14 @@ type rendezvousHostEnvTemplateData struct {
 }
 
 func saveRendezvousIPAddress(ipAddress string) error {
-	_, err := os.Stat(RENDEZVOUS_HOST_ENV_PATH)
-	if os.IsNotExist(err) {
-		// TODO: Should we not expect RENDEZVOUS_HOST_ENV_PATH to always exist?
-		// If so, this block can be removed.
-		file, err := os.OpenFile(RENDEZVOUS_HOST_ENV_PATH, os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			return fmt.Errorf("could not create and/or write to %s", RENDEZVOUS_HOST_ENV_PATH)
-		}
-		defer file.Close()
-
-		_, err = file.WriteString(fmt.Sprintf("NODE_ZERO_IP=%s\nSERVICE_BASE_URL=http://%s:8090/\nIMAGE_SERVICE_BASE_URL=http://%s:8888/\n", ipAddress, ipAddress, ipAddress))
-		if err != nil {
-			return fmt.Errorf("error writing NODE_ZERO_IP to %s", RENDEZVOUS_HOST_ENV_PATH)
-		}
-	} else {
-		templateData := &rendezvousHostEnvTemplateData{
-			RendezvousIP: ipAddress,
-		}
-		err = templateRendezvousHostEnv(templateData)
-		if err != nil {
-			return err
-		}
+	templateData := &rendezvousHostEnvTemplateData{
+		RendezvousIP: ipAddress,
 	}
+	err := templateRendezvousHostEnv(templateData)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -45,7 +28,7 @@ func templateRendezvousHostEnv(templateData interface{}) error {
 		return err
 	}
 
-	tmpl := template.New(RENDEZVOUS_HOST_ENV_PATH).Funcs(template.FuncMap{"replace": replace})
+	tmpl := template.New(RENDEZVOUS_HOST_ENV_PATH)
 	tmpl, err = tmpl.Parse(string(data))
 	if err != nil {
 		return err
@@ -63,9 +46,4 @@ func templateRendezvousHostEnv(templateData interface{}) error {
 	}
 
 	return nil
-}
-
-// replace is an utilitary function to do string replacement in templates.
-func replace(input, from, to string) string {
-	return strings.ReplaceAll(input, from, to)
 }

--- a/tools/agent_tui/ui/rendezvous_ip_template.go
+++ b/tools/agent_tui/ui/rendezvous_ip_template.go
@@ -1,0 +1,71 @@
+package ui
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+type rendezvousHostEnvTemplateData struct {
+	RendezvousIP string
+}
+
+func saveRendezvousIPAddress(ipAddress string) error {
+	_, err := os.Stat(RENDEZVOUS_HOST_ENV_PATH)
+	if os.IsNotExist(err) {
+		// TODO: Should we not expect RENDEZVOUS_HOST_ENV_PATH to always exist?
+		// If so, this block can be removed.
+		file, err := os.OpenFile(RENDEZVOUS_HOST_ENV_PATH, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return fmt.Errorf("could not create and/or write to %s", RENDEZVOUS_HOST_ENV_PATH)
+		}
+		defer file.Close()
+
+		_, err = file.WriteString(fmt.Sprintf("NODE_ZERO_IP=%s\nSERVICE_BASE_URL=http://%s:8090/\nIMAGE_SERVICE_BASE_URL=http://%s:8888/\n", ipAddress, ipAddress, ipAddress))
+		if err != nil {
+			return fmt.Errorf("error writing NODE_ZERO_IP to %s", RENDEZVOUS_HOST_ENV_PATH)
+		}
+	} else {
+		templateData := &rendezvousHostEnvTemplateData{
+			RendezvousIP: ipAddress,
+		}
+		err = templateRendezvousHostEnv(templateData)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func templateRendezvousHostEnv(templateData interface{}) error {
+	data, err := os.ReadFile(RENDEZVOUS_HOST_ENV_PATH)
+	if err != nil {
+		return err
+	}
+
+	tmpl := template.New(RENDEZVOUS_HOST_ENV_PATH).Funcs(template.FuncMap{"replace": replace})
+	tmpl, err = tmpl.Parse(string(data))
+	if err != nil {
+		return err
+	}
+
+	buf := &bytes.Buffer{}
+	if err := tmpl.Execute(buf, templateData); err != nil {
+		panic(err)
+	}
+	templatedFileData := buf.Bytes()
+
+	err = os.WriteFile(RENDEZVOUS_HOST_ENV_PATH, []byte(templatedFileData), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// replace is an utilitary function to do string replacement in templates.
+func replace(input, from, to string) string {
+	return strings.ReplaceAll(input, from, to)
+}

--- a/tools/agent_tui/ui/timeout_modal.go
+++ b/tools/agent_tui/ui/timeout_modal.go
@@ -81,5 +81,5 @@ func (u *UI) ShowTimeoutDialog() {
 func (u *UI) cancelUserPrompt() {
 	u.timeoutDialogCancel <- true
 	u.setIsTimeoutDialogActive(false)
-	u.returnFocusToChecks()
+	u.setFocusToChecks()
 }

--- a/tools/agent_tui/ui/timeout_modal.go
+++ b/tools/agent_tui/ui/timeout_modal.go
@@ -34,7 +34,7 @@ func (u *UI) createTimeoutModal(config checks.Config) {
 				u.app.Stop()
 			}
 		}).
-		SetBackgroundColor(newt.ColorBlack)
+		SetBackgroundColor(newt.ColorGray)
 	u.timeoutModal.
 		SetBorderColor(newt.ColorBlack).
 		SetBorder(true)

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -25,7 +25,7 @@ type UI struct {
 	dirty               atomic.Value // dirty flag set if the user interacts with the ui
 
 	rendezvousIPForm       *tview.Form
-	errorModal  *tview.Modal
+	errorModal             *tview.Modal
 	rendezvousIPFormActive atomic.Value
 
 	focusableItems []tview.Primitive // the list of widgets that can be focused
@@ -42,6 +42,7 @@ func NewUI(app *tview.Application, config checks.Config, logger *logrus.Logger) 
 	}
 	ui.nmtuiActive.Store(false)
 	ui.timeoutDialogActive.Store(false)
+	ui.rendezvousIPFormActive.Store(false)
 	ui.dirty.Store(false)
 	ui.create(config)
 	return ui
@@ -55,7 +56,7 @@ func (u *UI) GetPages() *tview.Pages {
 	return u.pages
 }
 
-func (u *UI) returnFocusToChecks() {
+func (u *UI) setFocusToChecks() {
 	// reset u.focusableItems to those on the checks page
 	u.focusableItems = []tview.Primitive{
 		u.netConfigForm.GetButton(0),
@@ -75,6 +76,7 @@ func (u *UI) setFocusToRendezvousIP() {
 	u.focusableItems = []tview.Primitive{
 		u.rendezvousIPForm.GetButton(0),
 		u.rendezvousIPForm.GetFormItemByLabel(FIELD_RENDEZVOUS_HOST_IP),
+		u.rendezvousIPForm.GetFormItemByLabel(FIELD_SET_IP),
 	}
 
 	u.pages.SwitchToPage(PAGE_RENDEZVOUS_IP)
@@ -118,6 +120,11 @@ func (u *UI) create(config checks.Config) {
 	u.createErrorModal()
 	u.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if !u.IsRendezvousIPFormActive() {
+			// Any interaction with the rendezvous IP form does
+			// not count as dirtying the UI. This prevents
+			// interactions with the rendezvous IP form from
+			// preventing the timeout dialog from appearing
+			// if the release image check passes.
 			u.dirty.Store(true)
 		}
 		return event

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -25,11 +25,11 @@ type UI struct {
 	dirty               atomic.Value // dirty flag set if the user interacts with the ui
 
 	// Rendezvous node IP workflow
-	rendezvousIPForm            *tview.Form
-	selectIPForm                *tview.Form
-	selectIPList                *tview.List
-	errorModal                  *tview.Modal
-	rendezvousIPFormActive      atomic.Value
+	rendezvousIPForm             *tview.Form
+	selectIPForm                 *tview.Form
+	selectIPList                 *tview.List
+	errorModal                   *tview.Modal
+	rendezvousIPFormActive       atomic.Value
 	rendezvousIPSaveSuccessModal *tview.Modal
 
 	focusableItems []tview.Primitive // the list of widgets that can be focused

--- a/tools/agent_tui/ui/ui.go
+++ b/tools/agent_tui/ui/ui.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/openshift/agent-installer-utils/tools/agent_tui/checks"
 	"github.com/rivo/tview"
+	"github.com/sirupsen/logrus"
 )
 
 type UI struct {
@@ -15,7 +16,7 @@ type UI struct {
 	primaryCheck        *tview.Table
 	checks              *tview.Table    // summary of all checks
 	details             *tview.TextView // where errors from checks are displayed
-	form                *tview.Form     // contains "Configure network" button
+	netConfigForm       *tview.Form     // contains "Configure network" button
 	timeoutModal        *tview.Modal    // popup window that times out
 	splashScreen        *tview.Modal    // display initial waiting message
 	nmtuiActive         atomic.Value
@@ -23,14 +24,21 @@ type UI struct {
 	timeoutDialogCancel chan bool
 	dirty               atomic.Value // dirty flag set if the user interacts with the ui
 
+	rendezvousIPForm       *tview.Form
+	errorModal  *tview.Modal
+	rendezvousIPFormActive atomic.Value
+
 	focusableItems []tview.Primitive // the list of widgets that can be focused
 	focusedItem    int               // the current focused widget
+
+	logger *logrus.Logger
 }
 
-func NewUI(app *tview.Application, config checks.Config) *UI {
+func NewUI(app *tview.Application, config checks.Config, logger *logrus.Logger) *UI {
 	ui := &UI{
 		app:                 app,
 		timeoutDialogCancel: make(chan bool),
+		logger:              logger,
 	}
 	ui.nmtuiActive.Store(false)
 	ui.timeoutDialogActive.Store(false)
@@ -48,12 +56,33 @@ func (u *UI) GetPages() *tview.Pages {
 }
 
 func (u *UI) returnFocusToChecks() {
+	// reset u.focusableItems to those on the checks page
+	u.focusableItems = []tview.Primitive{
+		u.netConfigForm.GetButton(0),
+		u.netConfigForm.GetButton(1),
+	}
 	u.pages.SwitchToPage(PAGE_CHECKSCREEN)
 	// shifting focus back to the "Configure network"
 	// button requires setting focus in this sequence
 	// form -> form-button
-	u.app.SetFocus(u.form)
-	u.app.SetFocus(u.form.GetButton(0))
+	u.app.SetFocus(u.netConfigForm)
+	u.app.SetFocus(u.netConfigForm.GetButton(0))
+}
+
+func (u *UI) setFocusToRendezvousIP() {
+	u.setIsRendezousIPFormActive(true)
+	// reset u.focusableItems to those on the rendezvous IP page
+	u.focusableItems = []tview.Primitive{
+		u.rendezvousIPForm.GetButton(0),
+		u.rendezvousIPForm.GetFormItemByLabel(FIELD_RENDEZVOUS_HOST_IP),
+	}
+
+	u.pages.SwitchToPage(PAGE_RENDEZVOUS_IP)
+	// shifting focus back to the "Configure network"
+	// button requires setting focus in this sequence
+	// form -> form-button
+	u.app.SetFocus(u.rendezvousIPForm)
+	u.app.SetFocus(u.rendezvousIPForm.GetFormItemByLabel(FIELD_RENDEZVOUS_HOST_IP))
 }
 
 func (u *UI) IsNMTuiActive() bool {
@@ -68,6 +97,14 @@ func (u *UI) IsTimeoutDialogActive() bool {
 	return u.timeoutDialogActive.Load().(bool)
 }
 
+func (u *UI) setIsRendezousIPFormActive(isActive bool) {
+	u.rendezvousIPFormActive.Store(isActive)
+}
+
+func (u *UI) IsRendezvousIPFormActive() bool {
+	return u.rendezvousIPFormActive.Load().(bool)
+}
+
 func (u *UI) IsDirty() bool {
 	return u.dirty.Load().(bool)
 }
@@ -77,8 +114,12 @@ func (u *UI) create(config checks.Config) {
 	u.createCheckPage(config)
 	u.createTimeoutModal(config)
 	u.createSplashScreen()
+	u.createRendezvousIPPage(config)
+	u.createErrorModal()
 	u.app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		u.dirty.Store(true)
+		if !u.IsRendezvousIPFormActive() {
+			u.dirty.Store(true)
+		}
 		return event
 	})
 }

--- a/vendor/github.com/joho/godotenv/.gitignore
+++ b/vendor/github.com/joho/godotenv/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/vendor/github.com/joho/godotenv/LICENCE
+++ b/vendor/github.com/joho/godotenv/LICENCE
@@ -1,0 +1,23 @@
+Copyright (c) 2013 John Barton
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/vendor/github.com/joho/godotenv/README.md
+++ b/vendor/github.com/joho/godotenv/README.md
@@ -1,0 +1,202 @@
+# GoDotEnv ![CI](https://github.com/joho/godotenv/workflows/CI/badge.svg) [![Go Report Card](https://goreportcard.com/badge/github.com/joho/godotenv)](https://goreportcard.com/report/github.com/joho/godotenv)
+
+A Go (golang) port of the Ruby [dotenv](https://github.com/bkeepers/dotenv) project (which loads env vars from a .env file).
+
+From the original Library:
+
+> Storing configuration in the environment is one of the tenets of a twelve-factor app. Anything that is likely to change between deployment environments–such as resource handles for databases or credentials for external services–should be extracted from the code into environment variables.
+>
+> But it is not always practical to set environment variables on development machines or continuous integration servers where multiple projects are run. Dotenv load variables from a .env file into ENV when the environment is bootstrapped.
+
+It can be used as a library (for loading in env for your own daemons etc.) or as a bin command.
+
+There is test coverage and CI for both linuxish and Windows environments, but I make no guarantees about the bin version working on Windows.
+
+## Installation
+
+As a library
+
+```shell
+go get github.com/joho/godotenv
+```
+
+or if you want to use it as a bin command
+
+go >= 1.17
+```shell
+go install github.com/joho/godotenv/cmd/godotenv@latest
+```
+
+go < 1.17
+```shell
+go get github.com/joho/godotenv/cmd/godotenv
+```
+
+## Usage
+
+Add your application configuration to your `.env` file in the root of your project:
+
+```shell
+S3_BUCKET=YOURS3BUCKET
+SECRET_KEY=YOURSECRETKEYGOESHERE
+```
+
+Then in your Go app you can do something like
+
+```go
+package main
+
+import (
+    "log"
+    "os"
+
+    "github.com/joho/godotenv"
+)
+
+func main() {
+  err := godotenv.Load()
+  if err != nil {
+    log.Fatal("Error loading .env file")
+  }
+
+  s3Bucket := os.Getenv("S3_BUCKET")
+  secretKey := os.Getenv("SECRET_KEY")
+
+  // now do something with s3 or whatever
+}
+```
+
+If you're even lazier than that, you can just take advantage of the autoload package which will read in `.env` on import
+
+```go
+import _ "github.com/joho/godotenv/autoload"
+```
+
+While `.env` in the project root is the default, you don't have to be constrained, both examples below are 100% legit
+
+```go
+godotenv.Load("somerandomfile")
+godotenv.Load("filenumberone.env", "filenumbertwo.env")
+```
+
+If you want to be really fancy with your env file you can do comments and exports (below is a valid env file)
+
+```shell
+# I am a comment and that is OK
+SOME_VAR=someval
+FOO=BAR # comments at line end are OK too
+export BAR=BAZ
+```
+
+Or finally you can do YAML(ish) style
+
+```yaml
+FOO: bar
+BAR: baz
+```
+
+as a final aside, if you don't want godotenv munging your env you can just get a map back instead
+
+```go
+var myEnv map[string]string
+myEnv, err := godotenv.Read()
+
+s3Bucket := myEnv["S3_BUCKET"]
+```
+
+... or from an `io.Reader` instead of a local file
+
+```go
+reader := getRemoteFile()
+myEnv, err := godotenv.Parse(reader)
+```
+
+... or from a `string` if you so desire
+
+```go
+content := getRemoteFileContent()
+myEnv, err := godotenv.Unmarshal(content)
+```
+
+### Precedence & Conventions
+
+Existing envs take precedence of envs that are loaded later.
+
+The [convention](https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use)
+for managing multiple environments (i.e. development, test, production)
+is to create an env named `{YOURAPP}_ENV` and load envs in this order:
+
+```go
+env := os.Getenv("FOO_ENV")
+if "" == env {
+  env = "development"
+}
+
+godotenv.Load(".env." + env + ".local")
+if "test" != env {
+  godotenv.Load(".env.local")
+}
+godotenv.Load(".env." + env)
+godotenv.Load() // The Original .env
+```
+
+If you need to, you can also use `godotenv.Overload()` to defy this convention
+and overwrite existing envs instead of only supplanting them. Use with caution.
+
+### Command Mode
+
+Assuming you've installed the command as above and you've got `$GOPATH/bin` in your `$PATH`
+
+```
+godotenv -f /some/path/to/.env some_command with some args
+```
+
+If you don't specify `-f` it will fall back on the default of loading `.env` in `PWD`
+
+By default, it won't override existing environment variables; you can do that with the `-o` flag.
+
+### Writing Env Files
+
+Godotenv can also write a map representing the environment to a correctly-formatted and escaped file
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+err := godotenv.Write(env, "./.env")
+```
+
+... or to a string
+
+```go
+env, err := godotenv.Unmarshal("KEY=value")
+content, err := godotenv.Marshal(env)
+```
+
+## Contributing
+
+Contributions are welcome, but with some caveats.
+
+This library has been declared feature complete (see [#182](https://github.com/joho/godotenv/issues/182) for background) and will not be accepting issues or pull requests adding new functionality or breaking the library API.
+
+Contributions would be gladly accepted that:
+
+* bring this library's parsing into closer compatibility with the mainline dotenv implementations, in particular [Ruby's dotenv](https://github.com/bkeepers/dotenv) and [Node.js' dotenv](https://github.com/motdotla/dotenv)
+* keep the library up to date with the go ecosystem (ie CI bumps, documentation changes, changes in the core libraries)
+* bug fixes for use cases that pertain to the library's purpose of easing development of codebases deployed into twelve factor environments
+
+*code changes without tests and references to peer dotenv implementations will not be accepted*
+
+1. Fork it
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Added some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create new Pull Request
+
+## Releases
+
+Releases should follow [Semver](http://semver.org/) though the first couple of releases are `v1` and `v1.1`.
+
+Use [annotated tags for all releases](https://github.com/joho/godotenv/issues/30). Example `git tag -a v1.2.1`
+
+## Who?
+
+The original library [dotenv](https://github.com/bkeepers/dotenv) was written by [Brandon Keepers](http://opensoul.org/), and this port was done by [John Barton](https://johnbarton.co/) based off the tests/fixtures in the original library.

--- a/vendor/github.com/joho/godotenv/godotenv.go
+++ b/vendor/github.com/joho/godotenv/godotenv.go
@@ -1,0 +1,228 @@
+// Package godotenv is a go port of the ruby dotenv library (https://github.com/bkeepers/dotenv)
+//
+// Examples/readme can be found on the GitHub page at https://github.com/joho/godotenv
+//
+// The TL;DR is that you make a .env file that looks something like
+//
+//	SOME_ENV_VAR=somevalue
+//
+// and then in your go code you can call
+//
+//	godotenv.Load()
+//
+// and all the env vars declared in .env will be available through os.Getenv("SOME_ENV_VAR")
+package godotenv
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const doubleQuoteSpecialChars = "\\\n\r\"!$`"
+
+// Parse reads an env file from io.Reader, returning a map of keys and values.
+func Parse(r io.Reader) (map[string]string, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return UnmarshalBytes(buf.Bytes())
+}
+
+// Load will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main).
+//
+// If you call Load without any args it will default to loading .env in the current path.
+//
+// You can otherwise tell it which files to load (there can be more than one) like:
+//
+//	godotenv.Load("fileone", "filetwo")
+//
+// It's important to note that it WILL NOT OVERRIDE an env variable that already exists - consider the .env file to set dev vars or sensible defaults.
+func Load(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, false)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Overload will read your env file(s) and load them into ENV for this process.
+//
+// Call this function as close as possible to the start of your program (ideally in main).
+//
+// If you call Overload without any args it will default to loading .env in the current path.
+//
+// You can otherwise tell it which files to load (there can be more than one) like:
+//
+//	godotenv.Overload("fileone", "filetwo")
+//
+// It's important to note this WILL OVERRIDE an env variable that already exists - consider the .env file to forcefully set all vars.
+func Overload(filenames ...string) (err error) {
+	filenames = filenamesOrDefault(filenames)
+
+	for _, filename := range filenames {
+		err = loadFile(filename, true)
+		if err != nil {
+			return // return early on a spazout
+		}
+	}
+	return
+}
+
+// Read all env (with same file loading semantics as Load) but return values as
+// a map rather than automatically writing values into env
+func Read(filenames ...string) (envMap map[string]string, err error) {
+	filenames = filenamesOrDefault(filenames)
+	envMap = make(map[string]string)
+
+	for _, filename := range filenames {
+		individualEnvMap, individualErr := readFile(filename)
+
+		if individualErr != nil {
+			err = individualErr
+			return // return early on a spazout
+		}
+
+		for key, value := range individualEnvMap {
+			envMap[key] = value
+		}
+	}
+
+	return
+}
+
+// Unmarshal reads an env file from a string, returning a map of keys and values.
+func Unmarshal(str string) (envMap map[string]string, err error) {
+	return UnmarshalBytes([]byte(str))
+}
+
+// UnmarshalBytes parses env file from byte slice of chars, returning a map of keys and values.
+func UnmarshalBytes(src []byte) (map[string]string, error) {
+	out := make(map[string]string)
+	err := parseBytes(src, out)
+
+	return out, err
+}
+
+// Exec loads env vars from the specified filenames (empty map falls back to default)
+// then executes the cmd specified.
+//
+// Simply hooks up os.Stdin/err/out to the command and calls Run().
+//
+// If you want more fine grained control over your command it's recommended
+// that you use `Load()`, `Overload()` or `Read()` and the `os/exec` package yourself.
+func Exec(filenames []string, cmd string, cmdArgs []string, overload bool) error {
+	op := Load
+	if overload {
+		op = Overload
+	}
+	if err := op(filenames...); err != nil {
+		return err
+	}
+
+	command := exec.Command(cmd, cmdArgs...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+// Write serializes the given environment and writes it to a file.
+func Write(envMap map[string]string, filename string) error {
+	content, err := Marshal(envMap)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(content + "\n")
+	if err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+// Marshal outputs the given environment as a dotenv-formatted environment file.
+// Each line is in the format: KEY="VALUE" where VALUE is backslash-escaped.
+func Marshal(envMap map[string]string) (string, error) {
+	lines := make([]string, 0, len(envMap))
+	for k, v := range envMap {
+		if d, err := strconv.Atoi(v); err == nil {
+			lines = append(lines, fmt.Sprintf(`%s=%d`, k, d))
+		} else {
+			lines = append(lines, fmt.Sprintf(`%s="%s"`, k, doubleQuoteEscape(v)))
+		}
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n"), nil
+}
+
+func filenamesOrDefault(filenames []string) []string {
+	if len(filenames) == 0 {
+		return []string{".env"}
+	}
+	return filenames
+}
+
+func loadFile(filename string, overload bool) error {
+	envMap, err := readFile(filename)
+	if err != nil {
+		return err
+	}
+
+	currentEnv := map[string]bool{}
+	rawEnv := os.Environ()
+	for _, rawEnvLine := range rawEnv {
+		key := strings.Split(rawEnvLine, "=")[0]
+		currentEnv[key] = true
+	}
+
+	for key, value := range envMap {
+		if !currentEnv[key] || overload {
+			_ = os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func readFile(filename string) (envMap map[string]string, err error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	defer file.Close()
+
+	return Parse(file)
+}
+
+func doubleQuoteEscape(line string) string {
+	for _, c := range doubleQuoteSpecialChars {
+		toReplace := "\\" + string(c)
+		if c == '\n' {
+			toReplace = `\n`
+		}
+		if c == '\r' {
+			toReplace = `\r`
+		}
+		line = strings.Replace(line, string(c), toReplace, -1)
+	}
+	return line
+}

--- a/vendor/github.com/joho/godotenv/parser.go
+++ b/vendor/github.com/joho/godotenv/parser.go
@@ -1,0 +1,271 @@
+package godotenv
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+const (
+	charComment       = '#'
+	prefixSingleQuote = '\''
+	prefixDoubleQuote = '"'
+
+	exportPrefix = "export"
+)
+
+func parseBytes(src []byte, out map[string]string) error {
+	src = bytes.Replace(src, []byte("\r\n"), []byte("\n"), -1)
+	cutset := src
+	for {
+		cutset = getStatementStart(cutset)
+		if cutset == nil {
+			// reached end of file
+			break
+		}
+
+		key, left, err := locateKeyName(cutset)
+		if err != nil {
+			return err
+		}
+
+		value, left, err := extractVarValue(left, out)
+		if err != nil {
+			return err
+		}
+
+		out[key] = value
+		cutset = left
+	}
+
+	return nil
+}
+
+// getStatementPosition returns position of statement begin.
+//
+// It skips any comment line or non-whitespace character.
+func getStatementStart(src []byte) []byte {
+	pos := indexOfNonSpaceChar(src)
+	if pos == -1 {
+		return nil
+	}
+
+	src = src[pos:]
+	if src[0] != charComment {
+		return src
+	}
+
+	// skip comment section
+	pos = bytes.IndexFunc(src, isCharFunc('\n'))
+	if pos == -1 {
+		return nil
+	}
+
+	return getStatementStart(src[pos:])
+}
+
+// locateKeyName locates and parses key name and returns rest of slice
+func locateKeyName(src []byte) (key string, cutset []byte, err error) {
+	// trim "export" and space at beginning
+	src = bytes.TrimLeftFunc(src, isSpace)
+	if bytes.HasPrefix(src, []byte(exportPrefix)) {
+		trimmed := bytes.TrimPrefix(src, []byte(exportPrefix))
+		if bytes.IndexFunc(trimmed, isSpace) == 0 {
+			src = bytes.TrimLeftFunc(trimmed, isSpace)
+		}
+	}
+
+	// locate key name end and validate it in single loop
+	offset := 0
+loop:
+	for i, char := range src {
+		rchar := rune(char)
+		if isSpace(rchar) {
+			continue
+		}
+
+		switch char {
+		case '=', ':':
+			// library also supports yaml-style value declaration
+			key = string(src[0:i])
+			offset = i + 1
+			break loop
+		case '_':
+		default:
+			// variable name should match [A-Za-z0-9_.]
+			if unicode.IsLetter(rchar) || unicode.IsNumber(rchar) || rchar == '.' {
+				continue
+			}
+
+			return "", nil, fmt.Errorf(
+				`unexpected character %q in variable name near %q`,
+				string(char), string(src))
+		}
+	}
+
+	if len(src) == 0 {
+		return "", nil, errors.New("zero length string")
+	}
+
+	// trim whitespace
+	key = strings.TrimRightFunc(key, unicode.IsSpace)
+	cutset = bytes.TrimLeftFunc(src[offset:], isSpace)
+	return key, cutset, nil
+}
+
+// extractVarValue extracts variable value and returns rest of slice
+func extractVarValue(src []byte, vars map[string]string) (value string, rest []byte, err error) {
+	quote, hasPrefix := hasQuotePrefix(src)
+	if !hasPrefix {
+		// unquoted value - read until end of line
+		endOfLine := bytes.IndexFunc(src, isLineEnd)
+
+		// Hit EOF without a trailing newline
+		if endOfLine == -1 {
+			endOfLine = len(src)
+
+			if endOfLine == 0 {
+				return "", nil, nil
+			}
+		}
+
+		// Convert line to rune away to do accurate countback of runes
+		line := []rune(string(src[0:endOfLine]))
+
+		// Assume end of line is end of var
+		endOfVar := len(line)
+		if endOfVar == 0 {
+			return "", src[endOfLine:], nil
+		}
+
+		// Work backwards to check if the line ends in whitespace then
+		// a comment (ie asdasd # some comment)
+		for i := endOfVar - 1; i >= 0; i-- {
+			if line[i] == charComment && i > 0 {
+				if isSpace(line[i-1]) {
+					endOfVar = i
+					break
+				}
+			}
+		}
+
+		trimmed := strings.TrimFunc(string(line[0:endOfVar]), isSpace)
+
+		return expandVariables(trimmed, vars), src[endOfLine:], nil
+	}
+
+	// lookup quoted string terminator
+	for i := 1; i < len(src); i++ {
+		if char := src[i]; char != quote {
+			continue
+		}
+
+		// skip escaped quote symbol (\" or \', depends on quote)
+		if prevChar := src[i-1]; prevChar == '\\' {
+			continue
+		}
+
+		// trim quotes
+		trimFunc := isCharFunc(rune(quote))
+		value = string(bytes.TrimLeftFunc(bytes.TrimRightFunc(src[0:i], trimFunc), trimFunc))
+		if quote == prefixDoubleQuote {
+			// unescape newlines for double quote (this is compat feature)
+			// and expand environment variables
+			value = expandVariables(expandEscapes(value), vars)
+		}
+
+		return value, src[i+1:], nil
+	}
+
+	// return formatted error if quoted string is not terminated
+	valEndIndex := bytes.IndexFunc(src, isCharFunc('\n'))
+	if valEndIndex == -1 {
+		valEndIndex = len(src)
+	}
+
+	return "", nil, fmt.Errorf("unterminated quoted value %s", src[:valEndIndex])
+}
+
+func expandEscapes(str string) string {
+	out := escapeRegex.ReplaceAllStringFunc(str, func(match string) string {
+		c := strings.TrimPrefix(match, `\`)
+		switch c {
+		case "n":
+			return "\n"
+		case "r":
+			return "\r"
+		default:
+			return match
+		}
+	})
+	return unescapeCharsRegex.ReplaceAllString(out, "$1")
+}
+
+func indexOfNonSpaceChar(src []byte) int {
+	return bytes.IndexFunc(src, func(r rune) bool {
+		return !unicode.IsSpace(r)
+	})
+}
+
+// hasQuotePrefix reports whether charset starts with single or double quote and returns quote character
+func hasQuotePrefix(src []byte) (prefix byte, isQuored bool) {
+	if len(src) == 0 {
+		return 0, false
+	}
+
+	switch prefix := src[0]; prefix {
+	case prefixDoubleQuote, prefixSingleQuote:
+		return prefix, true
+	default:
+		return 0, false
+	}
+}
+
+func isCharFunc(char rune) func(rune) bool {
+	return func(v rune) bool {
+		return v == char
+	}
+}
+
+// isSpace reports whether the rune is a space character but not line break character
+//
+// this differs from unicode.IsSpace, which also applies line break as space
+func isSpace(r rune) bool {
+	switch r {
+	case '\t', '\v', '\f', '\r', ' ', 0x85, 0xA0:
+		return true
+	}
+	return false
+}
+
+func isLineEnd(r rune) bool {
+	if r == '\n' || r == '\r' {
+		return true
+	}
+	return false
+}
+
+var (
+	escapeRegex        = regexp.MustCompile(`\\.`)
+	expandVarRegex     = regexp.MustCompile(`(\\)?(\$)(\()?\{?([A-Z0-9_]+)?\}?`)
+	unescapeCharsRegex = regexp.MustCompile(`\\([^$])`)
+)
+
+func expandVariables(v string, m map[string]string) string {
+	return expandVarRegex.ReplaceAllStringFunc(v, func(s string) string {
+		submatch := expandVarRegex.FindStringSubmatch(s)
+
+		if submatch == nil {
+			return s
+		}
+		if submatch[1] == "\\" || submatch[2] == "(" {
+			return submatch[0][1:]
+		} else if submatch[4] != "" {
+			return m[submatch[4]]
+		}
+		return s
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -45,6 +45,9 @@ github.com/gdamore/tcell/v2/terminfo/x/xfce
 github.com/gdamore/tcell/v2/terminfo/x/xterm
 github.com/gdamore/tcell/v2/terminfo/x/xterm_kitty
 github.com/gdamore/tcell/v2/terminfo/x/xterm_termite
+# github.com/joho/godotenv v1.5.1
+## explicit; go 1.12
+github.com/joho/godotenv
 # github.com/lucasb-eyer/go-colorful v1.2.0
 ## explicit; go 1.12
 github.com/lucasb-eyer/go-colorful


### PR DESCRIPTION
Added confirmation screens after the Rendezvous node IP is saved.
    
Instead of a checkbox to "randomly" choose of the Node's IP as the Rendezvous node IP, a list of all of this node's IP addresses is presented which allows the user to choose the exact one they want.
    
Added additional descriptions on the form to make the process more understandable.

Depends-on: https://github.com/openshift/agent-installer-utils/pull/38