### PR TITLE
AGENT-1152: Support custom openshift installer

### DIFF
--- a/tools/iso_builder/README.md
+++ b/tools/iso_builder/README.md
@@ -1,0 +1,14 @@
+# ABI OVE Image Builder
+This script generates 'agent-ove-\<arch\>.iso'
+
+## Custom OpenShift Installer Script
+
+This script allows you to test a locally built OpenShift installer by patching it with a release version.
+
+### Setup
+
+1. **Build the Installer**: Checkout and build the OpenShift installer binary.
+2. **Set Custom Installer Path**: Set the `CUSTOM_OPENSHIFT_INSTALLER_PATH` environment variable to point to your custom installer binary:
+   ```bash
+    CUSTOM_OPENSHIFT_INSTALLER_PATH=/path/to/installerCode ./tools/iso_builder/hack/build-ove-image.sh 
+    ```

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -95,7 +95,7 @@ function build_live_iso() {
     if [[ -n "${CUSTOM_OPENSHIFT_INSTALLER_PATH}" ]]; then
         echo "Using custom openshift installer from ${CUSTOM_OPENSHIFT_INSTALLER_PATH}"
         patch_openshift_install_release_version "${version}"
-        sudo podman run --rm -it --privileged --pull always --net=host -v "${APPLIANCE_WORK_DIR}"/:/assets:Z  "${PULL_SPEC}" build live-iso --log-level=debug --debug-base-ignition
+        sudo podman run --rm -it --privileged --pull always --net=host -v "${APPLIANCE_WORK_DIR}"/:/assets:Z  --env OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=${RELEASE_VERSION} "${PULL_SPEC}" build live-iso --log-level=debug --debug-base-ignition
     else
         sudo podman run --rm -it --privileged --pull always --net=host -v "${APPLIANCE_WORK_DIR}"/:/assets:Z  "${PULL_SPEC}" build live-iso --log-level=debug
     fi

--- a/tools/iso_builder/hack/utils.sh
+++ b/tools/iso_builder/hack/utils.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export CUSTOM_OPENSHIFT_INSTALLER_PATH="${CUSTOM_OPENSHIFT_INSTALLER_PATH:-}"
+
+function patch_openshift_install_release_version() {
+    local version=$1
+    local installer=${APPLIANCE_WORK_DIR}/openshift-install
+    cp ${CUSTOM_OPENSHIFT_INSTALLER_PATH}/bin/openshift-install ${installer}
+
+    local res=$(grep -oba ._RELEASE_VERSION_LOCATION_.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX ${installer})
+    local location=${res%%:*}
+
+    # If the release marker was found then it means that the version is missing
+    if [[ ! -z ${location} ]]; then
+        echo "Patching openshift-install with version ${version}"
+        printf "${version}\0" | dd of=${installer} bs=1 seek=${location} conv=notrunc &> /dev/null 
+        ${installer} version
+    else
+        echo "Version already patched"
+    fi
+}


### PR DESCRIPTION
- This PR helps you to test a locally built OpenShift installer by patching it with a release version.

`CUSTOM_OPENSHIFT_INSTALLER_PATH=/path/to/installerCode ./tools/iso_builder/hack/build-ove-image.sh  --release-image registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-03-17-053632 --arch x86_64 --pull-secret /home/test/dev-scripts/pull_secret.json`