### PR TITLE
AGENT-1137: Support both --ocp-version and --release-image-url

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -15,7 +15,7 @@ function usage() {
     echo "  ./hack/build-ove-image.sh [OPTIONS]"
     echo ""
     echo "Required Options:"
-    echo "  --pull-secret <path>           Path to the pull secret file (e.g., ~/pull_secret.json)"
+    echo "  --pull-secret-file <path>           Path to the pull secret file (e.g., ~/pull_secret.json)"
     echo ""
     echo "One of the following must be specified:"
     echo "  --release-image-url <url>      OpenShift release image URL (e.g., registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-03-18-173638)"
@@ -26,10 +26,10 @@ function usage() {
     echo "  --rendezvousIP <IP>            (Optional) Rendezvous IP for the cluster"
     echo ""
     echo "Examples:"
-    echo "$0 --pull-secret ~/pull_secret.json --release-image-url registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-03-18-173638"
-    echo "$0 --pull-secret ~/pull_secret.json --ocp-version 4.18.4"
-    echo "$0 --pull-secret ~/pull_secret.json --ocp-version 4.18.4 --arch x86_64"
-    echo "$0 --pull-secret ~/pull_secret.json --ocp-version 4.18.4 --rendezvousIP 192.168.122.2"
+    echo "$0 --pull-secret-file ~/pull_secret.json --release-image-url registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-03-18-173638"
+    echo "$0 --pull-secret-file ~/pull_secret.json --ocp-version 4.18.4"
+    echo "$0 --pull-secret-file ~/pull_secret.json --ocp-version 4.18.4 --arch x86_64"
+    echo "$0 --pull-secret-file ~/pull_secret.json --ocp-version 4.18.4 --rendezvousIP 192.168.122.2"
     echo "Outputs:"
     echo "  - agent-ove-x86_64.iso: Bootable agent OVE ISO image."
     echo
@@ -44,7 +44,7 @@ function parse_inputs() {
     while [[ "$#" -gt 0 ]]; do
         case $1 in
             --release-image-url) 
-                if [[ -n "$RELEASE_VERSION" ]]; then
+                if [[ -n "$RELEASE_IMAGE_VERSION" ]]; then
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
                     exit 1
                 fi
@@ -54,9 +54,9 @@ function parse_inputs() {
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
                     exit 1
                 fi
-                RELEASE_VERSION="$2"; shift ;;
+                RELEASE_IMAGE_VERSION="$2"; shift ;;
             --arch) ARCH="$2"; shift ;;
-            --pull-secret) PULL_SECRET="$2"; shift ;;
+            --pull-secret-file) PULL_SECRET_FILE="$2"; shift ;;
             --rendezvousIP) RENDEZVOUS_IP="$2"; shift ;;
             *) 
                 echo "Unknown parameter: $1" >&2
@@ -67,18 +67,18 @@ function parse_inputs() {
 }
 
 function validate_inputs() {
-    if [[ -z "${RELEASE_VERSION:-}" && -z "${RELEASE_IMAGE_URL:-}" ]]; then
+    if [[ -z "${RELEASE_IMAGE_VERSION:-}" && -z "${RELEASE_IMAGE_URL:-}" ]]; then
         echo "Error: Either OpenShift version (--ocp-version) or release image URL (--release-image-url) must be provided." >&2
         exit 1
     fi
 
-    if [[ -z "${PULL_SECRET:-}" ]]; then
-        echo "Error: Pull secret is required." >&2
+    if [[ -z "${PULL_SECRET_FILE:-}" ]]; then
+        echo "Error: Pull secret file is required." >&2
         exit 1
     fi
 
-    if [ ! -f "$PULL_SECRET" ]; then
-        echo "Error: File $PULL_SECRET does not exist." >&2
+    if [[ -n "$PULL_SECRET_FILE" && ! -f "$PULL_SECRET_FILE" ]]; then
+        echo "Error: File $PULL_SECRET_FILE does not exist." >&2
         exit 1
     fi
 
@@ -90,37 +90,35 @@ function validate_inputs() {
     fi
 
     # Ensure that the OCP version is in the format `x.y.z`
-    if [[ -n "$RELEASE_VERSION" && ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "Error: RELEASE_VERSION must be in the format major.minor.patch (e.g., 4.18.4)." >&2
+    if [[ -n "$RELEASE_IMAGE_VERSION" && ! "$RELEASE_IMAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: OpenShift version (--ocp-version) must be in the format major.minor.patch (e.g., 4.18.4)." >&2
         exit 1
     fi
 }
 
 function create_appliance_config() {
     echo "Creating appliance config..."
-    local version=$1
-    local release_url=$2
-    local arch=$3
-    local pullSecret=$4
+    local full_ocp_version
+    
+    if [ -n "${RELEASE_IMAGE_VERSION}" ]; then
+        echo "Using OCP version ${RELEASE_IMAGE_VERSION}"
+        full_ocp_version="${RELEASE_IMAGE_VERSION}"
+    fi
+    if [ -n "${RELEASE_IMAGE_URL}" ]; then
+        echo "Using release image ${RELEASE_IMAGE_URL}"
+        full_ocp_version=$(echo "\"$RELEASE_IMAGE_URL\"" | jq -r 'split(":")[1]')
+    fi
+    local major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
 
-    local major_minor_patch_version=$(echo "\"$FULL_OCP_VERSION\"" | jq -r 'split("-")[0]')
-
-    APPLIANCE_WORK_DIR="/tmp/iso_builder/appliance-assets-$FULL_OCP_VERSION"
+    APPLIANCE_WORK_DIR="/tmp/iso_builder/appliance-assets-$full_ocp_version"
     mkdir -p "${APPLIANCE_WORK_DIR}"
 
 # ToDo: Add rendezvousIp: user_specified_rendezvous_ip_address
-  cat >"${APPLIANCE_WORK_DIR}/appliance-config.yaml" <<EOF
+    cat << EOF >> ${APPLIANCE_WORK_DIR}/appliance-config.yaml
 apiVersion: v1beta1
 kind: ApplianceConfig
-ocpRelease:
-  # Always include version, either directly from --ocp-version or extracted from --release-image-url
-  $( [[ -n "$version" ]] && printf "version: \"%s\"\n" "$version" ) # Use value from --ocp-version, if provided
-  $( [[ -z "$version" && -n "$release_url" ]] && printf "version: \"%s\"\n" "$major_minor_patch_version" )  # Extract value from --release-image-url, if --ocp-version not specified
-  $( [[ -n "$version" ]] && printf "channel: candidate\n" ) # Add channel only if --ocp-version is provided
-  $( [[ -n "$version" ]] && printf "cpuArchitecture: \"%s\"\n" "$arch" ) # Add cpuArchitecture only if --ocp-version is provided
-  $( [[ -n "$release_url" ]] && printf "url: \"%s\"\n" "$release_url")  # Add URL if provided
 diskSizeGB: 200
-pullSecret: '$(cat "${pullSecret}")'
+pullSecret: '$(cat "${PULL_SECRET_FILE}")'
 imageRegistry:
   uri: quay.io/libpod/registry:2.8
 userCorePass: core
@@ -133,6 +131,22 @@ operators:
       - name: mtv-operator
       - name: kubernetes-nmstate-operator
 EOF
+
+    if [ -n "${RELEASE_IMAGE_VERSION}" ]; then
+        cat << EOF >> ${APPLIANCE_WORK_DIR}/appliance-config.yaml
+ocpRelease:
+  version: $major_minor_patch_version
+  channel: candidate
+  cpuArchitecture: $ARCH
+EOF
+    fi
+    if [ -n "${RELEASE_IMAGE_URL}" ]; then
+        cat << EOF >> ${APPLIANCE_WORK_DIR}/appliance-config.yaml
+ocpRelease:
+  version: $major_minor_patch_version
+  url: $RELEASE_IMAGE_URL
+EOF
+    fi
 }
 
 function build_live_iso() {
@@ -170,23 +184,22 @@ function extract_live_iso() {
 
 function setup_agent_artifacts() {
     echo "Preparing agent TUI artifacts..."
-    local PULL_SECRET=$1
-    local OSARCH
+    local osarch
     if [ "${ARCH}" == "x86_64" ]; then
-        OSARCH="amd64"
+        osarch="amd64"
     else
-        OSARCH="${ARCH}"
+        osarch="${ARCH}"
     fi
 
     local ARTIFACTS_DIR="${WORK_DIR}"/agent-artifacts
     mkdir -p "${ARTIFACTS_DIR}"
 
-    local IMAGE_PULL_SPEC=$(oc adm release info --registry-config="${PULL_SECRET}" --image-for=agent-installer-utils --filter-by-os=linux/"${OSARCH}" --insecure=true "${RELEASE_VERSION}")
+    local IMAGE_PULL_SPEC=$(oc adm release info --registry-config="${PULL_SECRET_FILE}" --image-for=agent-installer-utils --filter-by-os=linux/"${osarch}" --insecure=true "${RELEASE_IMAGE_VERSION}")
     
     local FILES=("/usr/bin/agent-tui" "/usr/lib64/libnmstate.so.*")
     for FILE in "${FILES[@]}"; do
         echo "Extracting $FILE..."
-        oc image extract --path="${FILE}:${ARTIFACTS_DIR}" --registry-config="${PULL_SECRET}" --filter-by-os=linux/"${OSARCH}" --insecure=true --confirm "${IMAGE_PULL_SPEC}"
+        oc image extract --path="${FILE}:${ARTIFACTS_DIR}" --registry-config="${PULL_SECRET_FILE}" --filter-by-os=linux/"${osarch}" --insecure=true --confirm "${IMAGE_PULL_SPEC}"
     done
 
     # Make sure files could be executed
@@ -208,7 +221,7 @@ function setup_agent_artifacts() {
     local IMAGE_DIR="${WORK_DIR}"/images/"${IMAGE}"
     mkdir -p "${IMAGE_DIR}"
     
-    skopeo copy -q --authfile="${PULL_SECRET}" docker://"${PULL_SPEC}" oci-archive:"${IMAGE_DIR}"/"${IMAGE}".tar
+    skopeo copy -q --authfile="${PULL_SECRET_FILE}" docker://"${PULL_SPEC}" oci-archive:"${IMAGE_DIR}"/"${IMAGE}".tar
 }
 
 function create_ove_iso() {
@@ -265,12 +278,11 @@ function cleanup() {
 
 function main()
 {
-    PULL_SECRET=""
-    RELEASE_VERSION=""
+    PULL_SECRET_FILE=""
+    RELEASE_IMAGE_VERSION=""
     RELEASE_IMAGE_URL=""
     ARCH=""
     RENDEZVOUS_IP=""
-    FULL_OCP_VERSION=""
 
     parse_inputs "$@"
     validate_inputs
@@ -278,19 +290,10 @@ function main()
     WORK_DIR="/tmp/iso_builder/ove-iso"
     mkdir -p "${WORK_DIR}"
 
-    # Check if appropriate parameters are provided and invoke the function
-    if [[ -n "${RELEASE_VERSION}" && -z "${RELEASE_IMAGE_URL}" ]]; then
-        FULL_OCP_VERSION="${RELEASE_VERSION}"
-        echo "Using OCP version ${RELEASE_VERSION}"
-        create_appliance_config "${RELEASE_VERSION}" "" "${ARCH}" "${PULL_SECRET}"
-    elif [[ -n "${RELEASE_IMAGE_URL}" && -z "${RELEASE_VERSION}" ]]; then
-        echo "Using release image ${RELEASE_IMAGE_URL}"
-        FULL_OCP_VERSION=$(echo "\"$RELEASE_IMAGE_URL\"" | jq -r 'split(":")[1]')
-        create_appliance_config "" "${RELEASE_IMAGE_URL}" "${ARCH}" "${PULL_SECRET}"
-    fi
+    create_appliance_config
     build_live_iso
     extract_live_iso
-    setup_agent_artifacts "${PULL_SECRET}"
+    setup_agent_artifacts
     create_ove_iso
     update_ignition
     cleanup

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -131,6 +131,7 @@ operators:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     packages:
       - name: mtv-operator
+      - name: kubernetes-nmstate-operator
 EOF
 }
 


### PR DESCRIPTION
Added support to specify OCP version via --ocp-version or extract version from --release-image-url.
- --release-image-url is mainly for testing/debugging non-released version
- Updated input validation to ensure only one of --ocp-version or --release-image-url is provided.
- Adds channel and cpuArchitecture in appliance-config only if --ocp-version is provided.
- Modified appliance config creation to dynamically include the OCP version based on inputs.
- Improved error handling and default architecture handling.
- Enhanced usage instructions to reflect new input options and examples.