### PR TITLE
AGENT-1118: Ensure the correct selinux labels are applied to agent tui files

### DIFF
--- a/tools/iso_builder/data/ove/data/files/usr/local/bin/setup-agent-tui.sh
+++ b/tools/iso_builder/data/ove/data/files/usr/local/bin/setup-agent-tui.sh
@@ -2,9 +2,4 @@
 set -e
 
 /usr/sbin/unsquashfs -f -d /usr/local/bin /run/media/iso/agent-artifacts/agent-artifacts.squashfs
-
-files=(/usr/local/bin/agent-tui /usr/local/bin/libnmstate.so.*)
-
-for file in "${files[@]}"; do
-    chcon system_u:object_r:bin_t:s0 "$file"
-done
+restorecon -FRv /usr/local/bin


### PR DESCRIPTION
This also avoids modifying the original /usr/local/bin labels, since it could have an impact in a later stage during the installation