### PR TITLE
AGENT-1151: Use internal appliance registry

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -122,8 +122,6 @@ apiVersion: v1beta1
 kind: ApplianceConfig
 diskSizeGB: 200
 pullSecret: '$(cat "${PULL_SECRET_FILE}")'
-imageRegistry:
-  uri: quay.io/libpod/registry:2.8
 userCorePass: core
 stopLocalRegistry: false
 enableDefaultSources: false


### PR DESCRIPTION
Appliance allows using an internal registry (see https://github.com/openshift/appliance/pull/349).  Use that (instead of the external one).