### PR TITLE
NO-ISSUE: ISOBuilder: Add Clean targets.

### DIFF
--- a/tools/iso_builder/Makefile
+++ b/tools/iso_builder/Makefile
@@ -1,16 +1,39 @@
+.PHONY: cleanall clean-appliance-temp-dir build-ove-iso
 ARCH ?= x86_64
 
-.PHONY:clean
-clean:
-	rm -rf /tmp/iso_builder/ove-iso
-	rm -rf ove-assets/
+cleanall:
+	@echo "🧹 Cleaning directory: /tmp/iso_builder";
+	@rm -rf /tmp/iso_builder; 
+	@echo "✅ Done."
 
-cleanall: clean
-	sudo rm -rf /tmp/iso_builder
+clean-appliance-temp-dir:
+	@read -p "🧹 Enter the appliance directory path to clean (e.g., /tmp/iso_builder/<OCP_VERSION>/appliance): " dir; \
+	if [ -d "$$dir" ]; then \
+		if [ -d "$$dir/temp" ]; then \
+			echo "🧹 Cleaning directory: $$dir/appliance"; \
+			sudo podman run --rm -it --privileged --net=host -v "$$dir/:/assets:Z" quay.io/edge-infrastructure/openshift-appliance:latest clean; \
+			echo "✅ Done."; \
+		else \
+			echo "❌ Error: The directory '$$dir/' does not contain a 'temp' folder."; \
+			echo "ℹ️ This may indicate that the appliance directory has already been cleaned, or the path is incorrect."; \
+			exit 1; \
+		fi \
+	else \
+		echo "❌ Error: Directory '$$dir' does not exist."; \
+		exit 1; \
+	fi
 	
-.PHONY: build-ove-iso
 build-ove-iso:
-	OCP_RELEASE_IMAGE=${OCP_RELEASE_IMAGE} \
-	PULL_SECRET=${PULL_SECRET} \
-	ARCH=${ARCH} \
-	hack/build-ove-image.sh --release-image ${OCP_RELEASE_IMAGE} --arch ${ARCH} --pull-secret ${PULL_SECRET}
+	@missing=0; \
+	for var in RELEASE_IMAGE_URL PULL_SECRET_FILE; do \
+	  if [ -z "$${!var}" ]; then \
+	    echo "❌  Error: Environment variable '$$var' is required."; \
+	    missing=1; \
+	  fi; \
+	done; \
+	if [ "$$missing" -eq 1 ]; then \
+	  echo ""; \
+	  echo "ℹ️   Usage: make build-ove-iso RELEASE_IMAGE_URL=<RELEASE_IMAGE> PULL_SECRET_FILE=</path/to/pull-secret.json>"; \
+	  exit 1; \
+	fi; \
+	hack/build-ove-image.sh --release-image-url ${RELEASE_IMAGE_URL} --pull-secret-file ${PULL_SECRET_FILE}

--- a/tools/iso_builder/Makefile
+++ b/tools/iso_builder/Makefile
@@ -2,38 +2,10 @@
 ARCH ?= x86_64
 
 cleanall:
-	@echo "🧹 Cleaning directory: /tmp/iso_builder";
-	@rm -rf /tmp/iso_builder; 
-	@echo "✅ Done."
+	hack/cleanup.sh cleanall
 
 clean-appliance-temp-dir:
-	@read -p "🧹 Enter the appliance directory path to clean (e.g., /tmp/iso_builder/<OCP_VERSION>/appliance): " dir; \
-	if [ -d "$$dir" ]; then \
-		if [ -d "$$dir/temp" ]; then \
-			echo "🧹 Cleaning directory: $$dir/appliance"; \
-			sudo podman run --rm -it --privileged --net=host -v "$$dir/:/assets:Z" quay.io/edge-infrastructure/openshift-appliance:latest clean; \
-			echo "✅ Done."; \
-		else \
-			echo "❌ Error: The directory '$$dir/' does not contain a 'temp' folder."; \
-			echo "ℹ️ This may indicate that the appliance directory has already been cleaned, or the path is incorrect."; \
-			exit 1; \
-		fi \
-	else \
-		echo "❌ Error: Directory '$$dir' does not exist."; \
-		exit 1; \
-	fi
+	hack/cleanup.sh clean-appliance-temp-dir
 	
 build-ove-iso:
-	@missing=0; \
-	for var in RELEASE_IMAGE_URL PULL_SECRET_FILE; do \
-	  if [ -z "$${!var}" ]; then \
-	    echo "❌  Error: Environment variable '$$var' is required."; \
-	    missing=1; \
-	  fi; \
-	done; \
-	if [ "$$missing" -eq 1 ]; then \
-	  echo ""; \
-	  echo "ℹ️   Usage: make build-ove-iso RELEASE_IMAGE_URL=<RELEASE_IMAGE> PULL_SECRET_FILE=</path/to/pull-secret.json>"; \
-	  exit 1; \
-	fi; \
 	hack/build-ove-image.sh --release-image-url ${RELEASE_IMAGE_URL} --pull-secret-file ${PULL_SECRET_FILE}

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -26,7 +26,6 @@ function create_appliance_config() {
     mkdir -p "${appliance_work_dir}"
     if [ ! -f "${appliance_work_dir}"/appliance-config.yaml ]; then
         echo "Creating appliance config..."
-        local major_minor_patch_version=$(echo "\"$full_ocp_version\"" | jq -r 'split("-")[0]')
         cfg=${appliance_work_dir}/appliance-config.yaml
         cat << EOF >> ${cfg}  
 apiVersion: v1beta1
@@ -112,8 +111,9 @@ function extract_live_iso() {
     else
         mkdir -p "${work_dir}"
         echo "Copying extracted appliance ISO contents to a writable directory."
-        sudo rsync -aH --info=progress2 "${appliance_mnt_dir}/" "${work_dir}/"
-        sudo chown -R $(whoami):$(whoami) "${work_dir}/"
+        $SUDO rsync -aH --info=progress2 "${appliance_mnt_dir}/" "${work_dir}/"
+        $SUDO chown -R $(whoami):$(whoami) "${work_dir}/"
+        $SUDO umount ${appliance_mnt_dir}
     fi
     volume_label=$(isoinfo -d -i "${appliance_work_dir}"/appliance.iso | grep "Volume id:" | cut -d' ' -f3-)
 }

--- a/tools/iso_builder/hack/cleanup.sh
+++ b/tools/iso_builder/hack/cleanup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage:"
+  echo "  cleanup.sh clean-tmp-dir"
+  echo "  cleanup.sh clean-appliance-dir"
+}
+
+cleanall() {
+  echo "Cleaning directory: /tmp/iso_builder"
+  rm -rf /tmp/iso_builder
+  echo "Done."
+}
+
+clean-appliance-temp-dir() {
+  read -p "Enter the appliance directory path to clean (e.g., /tmp/iso_builder/<OCP_VERSION>/appliance): " dir;
+
+  if [[ ! -d "$dir" ]]; then
+    echo "Error: Directory '$dir' does not exist."
+    exit 1
+  fi
+
+  if [[ ! -d "$dir/temp" ]]; then
+    echo "Error: The directory '$dir/' does not contain a 'temp' folder."
+    echo "This may indicate that the appliance directory has already been cleaned, or the provided path is incorrect."
+    exit 1
+  fi
+
+  echo "Cleaning directory: $dir"
+  sudo podman run --rm -it --privileged --net=host -v "$dir:/assets:Z" quay.io/edge-infrastructure/openshift-appliance:latest clean
+  echo "Done."
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+case "$1" in
+  cleanall)
+    cleanall
+    ;;
+  clean-appliance-temp-dir)
+    clean-appliance-temp-dir
+    ;;
+  *)
+    echo "Error: Unknown command '$1'"
+    usage
+    exit 1
+    ;;
+esac

--- a/tools/iso_builder/hack/helper.sh
+++ b/tools/iso_builder/hack/helper.sh
@@ -9,12 +9,14 @@ function parse_inputs() {
             --release-image-url) 
                 if [[ -n "$RELEASE_IMAGE_VERSION" ]]; then
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
+                    usage
                     exit 1
                 fi
                 RELEASE_IMAGE_URL="$2"; shift ;;
             --ocp-version) 
                 if [[ -n "$RELEASE_IMAGE_URL" ]]; then
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
+                    usage
                     exit 1
                 fi
                 RELEASE_IMAGE_VERSION="$2"; shift ;;
@@ -24,6 +26,7 @@ function parse_inputs() {
             --dir) DIR_PATH="$2"; shift ;;
             *) 
                 echo "Unknown parameter: $1" >&2
+                usage
                 exit 1 ;;
         esac
         shift
@@ -33,11 +36,13 @@ function parse_inputs() {
 function validate_inputs() {
     if [[ -z "${RELEASE_IMAGE_VERSION:-}" && -z "${RELEASE_IMAGE_URL:-}" ]]; then
         echo "Error: Either OpenShift version (--ocp-version) or release image URL (--release-image-url) must be provided." >&2
+        usage
         exit 1
     fi
 
     if [[ -z "${PULL_SECRET_FILE:-}" ]]; then
         echo "Error: Pull secret file is required." >&2
+        usage
         exit 1
     fi
 
@@ -56,6 +61,7 @@ function validate_inputs() {
     # Ensure that the OCP version is in the format `x.y.z`
     if [[ -n "$RELEASE_IMAGE_VERSION" && ! "$RELEASE_IMAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Error: OpenShift version (--ocp-version) must be in the format major.minor.patch (e.g., 4.18.4)." >&2
+        usage
         exit 1
     fi
     if [[ -n "$SSH_KEY_FILE" && ! -f "$SSH_KEY_FILE" ]]; then


### PR DESCRIPTION
Unmount appliance mount directory
Add new targets
- `make cleanall` : Cleans default ISOBuilder tmp directory ( /tmp/iso_builder) 
- `make clean-appliance-temp-dir`:  Invokes appliance container to clean appliance temp directory  ( /tmp/iso_builder/<OCP_VERSION>/appliance/temp)
- `make build-ove-iso`: Validates required inputs and creates OVE ISO in default location ( /tmp/iso_builder) 

