### PR TITLE
NO-ISSUE: Remove extra doneFunc() call

### DIFF
--- a/tools/agent_tui/ui/nmtui.go
+++ b/tools/agent_tui/ui/nmtui.go
@@ -58,5 +58,4 @@ func (u *UI) showNMTUIWithErrorDialog(doneFunc func()) {
 			})
 		u.pages.AddPage("error", errorDialog, false, true)
 	}
-	doneFunc()
 }


### PR DESCRIPTION
The doneFunc() is only called when there is an error executing ShowNMTUI and doesn't need to be called at the end of showNMTUIWithErrorDialog.