### PR TITLE
NO-ISSUE: ISOBuilder-Add support-tools image for oc debug

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -47,6 +47,8 @@ EOF
         fi
 
         cat << EOF >> ${cfg} 
+additionalImages:
+  - name: registry.redhat.io/rhel9/support-tools
 operators:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     packages:


### PR DESCRIPTION
Adds `registry.redhat.io/rhel9/support-tools` under `additionalImages` in appliance-config.yaml. This image is required by `oc debug` to launch a debug pod with diagnostic tools for troubleshooting networking, file system, and process issues across nodes and pods.