### PR TITLE
OCPBUGS-55515: Include cnv operator in ISO builder script

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -52,6 +52,7 @@ additionalImages:
 operators:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     packages:
+      - name: kubevirt-hyperconverged
       - name: mtv-operator
       - name: kubernetes-nmstate-operator
       - name: node-healthcheck-operator


### PR DESCRIPTION
Include the cnv operator using the name from the operator list.