### PR TITLE
OCPBUGS-55708: Include RHEL 9 guest image to support VM launches via …

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -50,6 +50,7 @@ EOF
         cat << EOF >> ${cfg} 
 additionalImages:
   - name: registry.redhat.io/rhel9/support-tools
+  - name: registry.redhat.io/rhel9/rhel-guest-image:9.5-1736773155
 operators:
   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.19
     packages:


### PR DESCRIPTION
…local registry

Adds the RHEL 9 guest image required by OpenShift Virtualization, enabling customers to start RHEL 9 VMs directly from their local image registry.