### PR TITLE
OCPBUGS-56223: Fix nmtui redirection after quit

### DIFF
--- a/tools/agent_tui/ui/rendezvous_ip_connectivity_fail_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_connectivity_fail_modal.go
@@ -22,7 +22,8 @@ func (u *UI) showRendezvousIPConnectivityFailModal(ipAddress string, focusForBac
 			focusForBackButton()
 		}
 		if buttonLabel == CONFIGURE_NETWORK_BUTTON {
-			u.ShowNMTUI()
+			u.showNMTUIWithErrorDialog(u.setFocusToRendezvousIP)
+			u.pages.SwitchToPage(PAGE_RENDEZVOUS_IP_CONNECTIVITY_FAIL)
 		}
 
 	})

--- a/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_save_success_modal.go
@@ -28,7 +28,8 @@ func (u *UI) showRendezvousIPSaveSuccessModal(savedIP string, focusForBackButton
 			focusForBackButton()
 		}
 		if buttonLabel == CONFIGURE_NETWORK_BUTTON {
-			u.ShowNMTUI()
+			u.showNMTUIWithErrorDialog(u.setFocusToRendezvousIP)
+			u.pages.SwitchToPage(PAGE_RENDEZVOUS_IP_SAVE_SUCCESS)
 		}
 
 	})

--- a/tools/agent_tui/ui/rendezvous_ip_select.go
+++ b/tools/agent_tui/ui/rendezvous_ip_select.go
@@ -148,6 +148,7 @@ func (u *UI) updateSelectIPList(ipAddresses []string) {
 					u.refreshSelectIPList()
 					u.setFocusToSelectIP()
 				})
+				u.setFocusToSelectIP()
 			default:
 				err := u.saveRendezvousIPAddress(selected)
 				if err != nil {

--- a/tools/agent_tui/ui/rendezvous_modal.go
+++ b/tools/agent_tui/ui/rendezvous_modal.go
@@ -21,10 +21,10 @@ func (u *UI) createRendezvousModal() {
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			switch buttonLabel {
 			case CONTINUE_BUTTON, BACK_BUTTON:
-				u.setFocusToRendezvousIP()
 			case CONFIGURE_NETWORK_BUTTON:
-				u.ShowNMTUI()
+				u.showNMTUIWithErrorDialog(u.setFocusToRendezvousIP)
 			}
+			u.setFocusToRendezvousIP()
 		}).
 		SetBackgroundColor(newt.ColorGray)
 	u.rendezvousModal.
@@ -41,6 +41,6 @@ func (u *UI) showRendezvousModal(text string, buttons []string) {
 	u.rendezvousModal.ClearButtons()
 	u.rendezvousModal.AddButtons(buttons)
 	u.rendezvousModal.SetText(text)
+	u.pages.SwitchToPage(PAGE_RENDEZVOUS_MODAL)
 	u.app.SetFocus(u.rendezvousModal)
-	u.pages.ShowPage(PAGE_RENDEZVOUS_MODAL)
 }


### PR DESCRIPTION
After quiting nmtui in the install-interactive-disconnected workflow the user should stay in the rendezvous IP selection screens and not shown the release image checks page.

The bug was caused by
https://github.com/openshift/agent-installer-utils/pull/73 which removed the original redirect back to the rendezvous IP pages to fix an issue with the bad_dns e2e test.