### PR TITLE
OCPBUGS-56880: Log error from nmtui and change modal background

### DIFF
--- a/tools/agent_tui/ui/nmtui.go
+++ b/tools/agent_tui/ui/nmtui.go
@@ -49,8 +49,9 @@ func (u *UI) ShowNMTUI() error {
 
 func (u *UI) showNMTUIWithErrorDialog(doneFunc func()) {
 	if err := u.ShowNMTUI(); err != nil {
+		u.logger.Infof("error from ShowNMTUI: %v", err)
 		errorDialog := tview.NewModal().
-			SetBackgroundColor(newt.ColorBlack).
+			SetBackgroundColor(newt.ColorGray).
 			SetText(err.Error()).
 			AddButtons([]string{"Ok"}).
 			SetDoneFunc(func(buttonIndex int, buttonLabel string) {


### PR DESCRIPTION
Modal background was set to black making the text (which is also in black) invisible.

When there is an error from nmtui, log it so that is it can be seen there for debugging. Otherwise the error is only visible from the UI.