### PR TITLE
AGENT-1193: Custom openshift-install to generate unconfigued-ign

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -138,7 +138,12 @@ function build_live_iso() {
     if [ ! -f "${appliance_work_dir}"/appliance.iso ]; then
         echo "Building appliance ISO..."
         local pull_spec=quay.io/edge-infrastructure/openshift-appliance@sha256:82836d7a7e257e83c5065fcdb731a09b8bec7228be3ee8c9122b4b5c45463b73
-        $SUDO podman run --rm -it --privileged --pull always --net=host -v "${appliance_work_dir}"/:/assets:Z  "${pull_spec}" build live-iso --log-level debug
+        local appliance_command="podman run --rm -it --privileged --pull always --net=host -v ${appliance_work_dir}/:/assets:Z  ${pull_spec} build live-iso --log-level debug"
+        if [ -f "${appliance_work_dir}/openshift-install" ]; then
+            echo "openshift-install binary at ${appliance_work_dir} will be used to generate the unconfigured-ignition"
+            appliance_command="$appliance_command --debug-base-ignition"
+        fi
+        $SUDO $appliance_command
     else
         echo "Skip building appliance ISO. Reusing ${appliance_work_dir}/appliance.iso."
     fi


### PR DESCRIPTION
The openshift appliance build command has a flag called

--debug-base-ignition

when provided, allows using a custom openshift-install binary to generate the unconfigured-ignition instead of the binary downloaded from the release.

When the flag is provided, openshift appliance looks for the custom openshift-install binary in its assets directory.

The build script has been updated to detect if a custom openshift-install binary has been provided in the assets directory and if present, adds the --debug-base-ignition flag.

One use case would be for dev-scripts. When the configuration variable KNI_INSTALL_FROM_GIT is set to true, dev-scripts builds the openshift-install binary from source and uses it to generate the agent ISO. We would like the appliance to also use the same openshift-install binary that was generated from source to build its images. A supporting PR in dev-scripts will copy the openshift-install binary to the appliance's asset directory when KNI_INSTALL_FROM_GIT=true. In combination with this PR, it will activate the --debug-base-ignition flag.