### PR TITLE
AGENT-1205: Do not include agent-tui and related services

### DIFF
--- a/tools/iso_builder/README.md
+++ b/tools/iso_builder/README.md
@@ -22,11 +22,10 @@ By default:
 ## Pre-requisites
 
 1. xorriso (see [xorriso](https://www.gnu.org/software/xorriso/) for more information). On CentOS, RHEL, run `sudo dnf install -y xorriso`
-2. coreos-installer (see [coreos-installer](https://coreos.github.io/coreos-installer/getting-started/) for more information). On CentOS, RHEL, run `sudo dnf install -y coreos-installer`
-3. isohybrid (see [isohybrid](https://man.archlinux.org/man/core/syslinux/isohybrid.1.en) for more information). On CentOS, RHEL, run `sudo dnf install -y syslinux`
-4. oc (see [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands) for more information).
-5. podman (see [podman](https://podman.io/docs/installation) for more information).
-6. skopeo (see [skopeo](https://github.com/containers/skopeo/blob/main/install.md) for more information). On RHEL / CentOS Stream ≥ 8, run `sudo dnf -y install skopeo`
+2. isohybrid (see [isohybrid](https://man.archlinux.org/man/core/syslinux/isohybrid.1.en) for more information). On CentOS, RHEL, run `sudo dnf install -y syslinux`
+3. oc (see [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands) for more information).
+4. podman (see [podman](https://podman.io/docs/installation) for more information).
+5. skopeo (see [skopeo](https://github.com/containers/skopeo/blob/main/install.md) for more information). On RHEL / CentOS Stream ≥ 8, run `sudo dnf -y install skopeo`
 
 
 ## Quick Start


### PR DESCRIPTION
The agent-tui and nmstate libraries will be extracted during boot by https://github.com/openshift/installer/pull/9828.

They do not need to be inserted into the ISO.

Merge https://github.com/openshift/installer/pull/9828 first.