### PR TITLE
[release-4.19] OCPBUGS-59666: Enable 'q' and 'c' hotkeys for quit and configure network

### DIFF
--- a/tools/agent_tui/ui/check_page.go
+++ b/tools/agent_tui/ui/check_page.go
@@ -13,8 +13,8 @@ import (
 const (
 	CONFIGURE_NETWORK_LABEL  string = "Configure Networking"
 	RELEASE_IMAGE_LABEL      string = "Release Image"
-	CONFIGURE_NETWORK_BUTTON string = "<Configure Network>"
-	QUIT_BUTTON              string = "<Quit>"
+	CONFIGURE_NETWORK_BUTTON string = "<[::u]C[::-]onfigure Network>"
+	QUIT_BUTTON              string = "<[::u]Q[::-]uit>"
 	PAGE_CHECKSCREEN         string = "checkScreen"
 
 	mainFlexHeight            = 10
@@ -175,6 +175,14 @@ func (u *UI) createCheckPage(config checks.Config) {
 			u.focusedItem--
 			if u.focusedItem < 0 {
 				u.focusedItem = len(u.focusableItems) - 1
+			}
+
+		case tcell.KeyRune:
+			if event.Rune() == 'Q' || event.Rune() == 'q' {
+				u.app.Stop()
+			}
+			if event.Rune() == 'C' || event.Rune() == 'c' {
+				u.showNMTUIWithErrorDialog(u.setFocusToChecks)
 			}
 
 		default:

--- a/tools/agent_tui/ui/rendezvous_ip_connectivity_fail_modal.go
+++ b/tools/agent_tui/ui/rendezvous_ip_connectivity_fail_modal.go
@@ -21,7 +21,7 @@ func (u *UI) showRendezvousIPConnectivityFailModal(ipAddress string, focusForBac
 		if buttonLabel == BACK_BUTTON {
 			focusForBackButton()
 		}
-		if buttonLabel == CONFIGURE_NETWORK_BUTTON {
+		if buttonLabel == RENDEZVOUS_CONFIGURE_NETWORK_BUTTON {
 			u.showNMTUIWithErrorDialog(u.setFocusToRendezvousIP)
 			u.pages.SwitchToPage(PAGE_RENDEZVOUS_IP_CONNECTIVITY_FAIL)
 		}
@@ -31,7 +31,7 @@ func (u *UI) showRendezvousIPConnectivityFailModal(ipAddress string, focusForBac
 	u.connectivityFailModal.SetBorder(true)
 	u.connectivityFailModal.SetButtonBackgroundColor(newt.ColorGray).
 		SetButtonTextColor(newt.ColorRed)
-	userPromptButtons := []string{SAVE_AND_CONTINUE_BUTTON, BACK_BUTTON, CONFIGURE_NETWORK_BUTTON}
+	userPromptButtons := []string{SAVE_AND_CONTINUE_BUTTON, BACK_BUTTON, RENDEZVOUS_CONFIGURE_NETWORK_BUTTON}
 	u.connectivityFailModal.AddButtons(userPromptButtons)
 	u.connectivityFailModal.SetText(CONNECTIVITY_CHECK_FAIL_TEXT_FORMAT)
 

--- a/tools/agent_tui/ui/rendezvous_ip_select.go
+++ b/tools/agent_tui/ui/rendezvous_ip_select.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	EMPTY_OPTION = "" // list option used as spacing between IP addresses and <Back> button
+	EMPTY_OPTION                        = "" // list option used as spacing between IP addresses and <Back> button
+	RENDEZVOUS_CONFIGURE_NETWORK_BUTTON = "<Configure Network>"
 )
 
 func (u *UI) createSelectHostIPPage() {
@@ -129,13 +130,12 @@ func (u *UI) refreshSelectIPList() {
 func (u *UI) updateSelectIPList(ipAddresses []string) {
 	u.selectIPList.Clear()
 	backOption := "<Back>"
-	configureNetworkOption := "<Configure Network>"
 	options := ipAddresses
 	if len(ipAddresses) > 0 {
 		// only add spacer line if there are IP addresses
 		options = append(options, EMPTY_OPTION)
 	}
-	options = append(options, backOption, configureNetworkOption)
+	options = append(options, backOption, RENDEZVOUS_CONFIGURE_NETWORK_BUTTON)
 	for _, selected := range options {
 		u.selectIPList.AddItem(selected, "", rune(0), func() {
 			switch selected {
@@ -143,7 +143,7 @@ func (u *UI) updateSelectIPList(ipAddresses []string) {
 				// spacing between IP addresses and buttons
 			case backOption:
 				u.setFocusToRendezvousIP()
-			case configureNetworkOption:
+			case RENDEZVOUS_CONFIGURE_NETWORK_BUTTON:
 				u.showNMTUIWithErrorDialog(func() {
 					u.refreshSelectIPList()
 					u.setFocusToSelectIP()

--- a/tools/agent_tui/ui/rendezvous_ip_select_test.go
+++ b/tools/agent_tui/ui/rendezvous_ip_select_test.go
@@ -17,7 +17,7 @@ func TestSelectIPListNavigation(t *testing.T) {
 	list.AddItem("IP2", "", '2', nil)
 	list.AddItem("", "", '3', nil)
 	list.AddItem(BACK_BUTTON, "", '4', nil)
-	list.AddItem(CONFIGURE_NETWORK_BUTTON, "", '5', nil)
+	list.AddItem(RENDEZVOUS_CONFIGURE_NETWORK_BUTTON, "", '5', nil)
 
 	list.SetInputCapture(getSelectIPListInputCapture(list))
 
@@ -54,7 +54,7 @@ func TestSelectIPListNavigation1Address(t *testing.T) {
 	list.AddItem("IP0", "", '0', nil)
 	list.AddItem("", "", '1', nil)
 	list.AddItem(BACK_BUTTON, "", '2', nil)
-	list.AddItem(CONFIGURE_NETWORK_BUTTON, "", '3', nil)
+	list.AddItem(RENDEZVOUS_CONFIGURE_NETWORK_BUTTON, "", '3', nil)
 
 	list.SetInputCapture(getSelectIPListInputCapture(list))
 

--- a/tools/agent_tui/ui/rendezvous_modal.go
+++ b/tools/agent_tui/ui/rendezvous_modal.go
@@ -21,7 +21,7 @@ func (u *UI) createRendezvousModal() {
 		SetDoneFunc(func(buttonIndex int, buttonLabel string) {
 			switch buttonLabel {
 			case CONTINUE_BUTTON, BACK_BUTTON:
-			case CONFIGURE_NETWORK_BUTTON:
+			case RENDEZVOUS_CONFIGURE_NETWORK_BUTTON:
 				u.showNMTUIWithErrorDialog(u.setFocusToRendezvousIP)
 			}
 			u.setFocusToRendezvousIP()


### PR DESCRIPTION
This is a manual cherry pick of https://github.com/openshift/agent-installer-utils/pull/107 [OCPBUGS-59664](https://issues.redhat.com/browse/OCPBUGS-59664).

Entering TAB or LEFT keys after ESC is not reliable and sometimes are not registered through "virsh send-key" leaving the bad_dns test unable to quit agent-tui. Using TAB or LEFT makes exiting out of agent-tui a navigational exercise.

To provide a simplier way to exit agent-tui, the checks page has been updated to recognize the letter 'q' as an alternative means to exit the agent-tui.