### PR TITLE
OCPBUGS-59724: add back NHR and FAR operators

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -59,9 +59,15 @@ operators:
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable
+      - name: node-healthcheck-operator
+        channels:
+          - name: stable          
       - name: node-maintenance-operator
         channels:
           - name: stable
+      - name: fence-agents-remediation
+        channels:
+          - name: stable          
       - name: cluster-kube-descheduler-operator
         channels:
           - name: stable


### PR DESCRIPTION
This patch partially reverts https://github.com/openshift/agent-installer-utils/pull/117 to reintroduce in the supported list both the NHR and FAR OLM operators