### PR TITLE
AGENT-1254: Switch to agent-installer-ui image

### DIFF
--- a/tools/iso_builder/data/ove/data/systemd/agent-setup-tui.service
+++ b/tools/iso_builder/data/ove/data/systemd/agent-setup-tui.service
@@ -7,7 +7,7 @@ Requires=run-media-iso.mount
 [Service]
 Type=oneshot
 
-ExecStartPre=/bin/bash -c "podman tag $(podman load -q -i /run/media/iso/images/assisted-install-ui/assisted-install-ui.tar | awk '{print $NF}') localhost/agent-installer-ui:latest"
+ExecStartPre=/bin/bash -c "podman tag $(podman load -q -i /run/media/iso/images/agent-installer-ui/agent-installer-ui.tar | awk '{print $NF}') localhost/agent-installer-ui:latest"
 ExecStart=/bin/bash /usr/local/bin/setup-agent-tui.sh
 
 [Install]

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -180,7 +180,7 @@ function extract_live_iso() {
 }
 
 function setup_agent_artifacts() {
-    local image=assisted-install-ui
+    local image=agent-installer-ui
     local pull_spec=registry.ci.openshift.org/ocp/4.20:"${image}"
     local image_dir="${work_dir}"/images/"${image}"
     


### PR DESCRIPTION
The UI image is being renamed to agent-installer-ui.

See https://github.com/openshift/release/pull/67480

We switch the UI to use to the new image name. The old name assisted-install-ui will be retired.