### PR TITLE
NO-ISSUE: Move mtv-operator back to v2.8 for 4.20

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -55,7 +55,7 @@ operators:
           - name: stable
       - name: mtv-operator
         channels:
-          - name: release-v2.9
+          - name: release-v2.8
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable


### PR DESCRIPTION
4.20 expects the mtv-operator to be v2.8. It was moved forward to v2.9 for release-4.19.

See
https://github.com/openshift/agent-installer-utils/pull/124 https://issues.redhat.com//browse/OCPBUGS-59187