### PR TITLE
AGENT-1270: use agent-preinstall-image-builder image for building the ISO

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -142,9 +142,9 @@ EOF
 
 function build_live_iso() {
     if [ ! -f "${appliance_work_dir}"/appliance.iso ]; then
-        echo "Building appliance ISO..."
-        local pull_spec=quay.io/edge-infrastructure/openshift-appliance@sha256:82836d7a7e257e83c5065fcdb731a09b8bec7228be3ee8c9122b4b5c45463b73
-        $SUDO podman run --rm -it --privileged --pull always --net=host -v "${appliance_work_dir}"/:/assets:Z  "${pull_spec}" build live-iso --log-level debug
+       local appliance_image=registry.ci.openshift.org/ocp/4.20:agent-preinstall-image-builder
+        echo "Building appliance ISO (image: ${appliance_image})"
+        $SUDO podman run --authfile "${PULL_SECRET_FILE}" --rm -it --privileged --pull always --net=host -v "${appliance_work_dir}"/:/assets:Z  "${appliance_image}" build live-iso --log-level debug
     else
         echo "Skip building appliance ISO. Reusing ${appliance_work_dir}/appliance.iso."
     fi


### PR DESCRIPTION
From this patch we'll start using the `registry.ci.openshift.org/ocp/<OCP version>:agent-preinstall-image-builder` appliance image, as it will follow the standard release branching