### PR TITLE
WIP AGENT-1252: Add Dockerfile for OVE ISO creation

### DIFF
--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -1,0 +1,35 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1753978585
+
+USER root
+
+ARG PULL_SECRET_CONTAINER_PATH="/run/secrets/my_pull_secret_file" # Good default for secrets
+
+# RUN dnf install -y --enablerepo=ubi-9-baseos-rpms gcc xorriso syslinux coreos-installer && dnf clean all
+
+# Set the working directory inside the container
+WORKDIR /app
+
+COPY hack/ hack/
+COPY data/ data/
+
+# RUN dnf install -y --enablerepo=ubi-9-baseos-rpms gcc jq podman xorriso syslinux coreos-installer && dnf clean all
+RUN dnf install -y gcc jq podman && dnf clean all
+
+RUN chmod +x hack/build-ove-image.sh hack/helper.sh
+
+# Create the final output directory /app/output and ensure it's writable
+RUN mkdir -p /app/output && \
+    chmod g+rwx /app/output && \
+    chgrp 0 /app/output
+
+# Create the temporary ISO build directory as expected by the script
+RUN mkdir -p /tmp/iso_builder && \
+    chmod g+rwx /tmp/iso_builder && \
+    chgrp 0 /tmp/iso_builder
+
+# Define the volume for persistent storage of the generated ISO
+VOLUME /app/output
+
+RUN --mount=type=secret,id=my_pull_secret,target=${PULL_SECRET_CONTAINER_PATH} \
+    hack/build-ove-image.sh --pull-secret-file "${PULL_SECRET_CONTAINER_PATH}" --ocp-version 4.20.0
+


### PR DESCRIPTION
Adds a Dockerfile that containerizes the script to create an OVE ISO.

Currently this doesn't build. When run with
`$ podman build --authfile ./pull-secret.json --secret id=my_pull_secret,src=./pull-secret.json -t my-iso-builder:latest -f Dockerfile
`
It results in a uid issue:
```
Trying to pull registry.ci.openshift.org/ocp/4.20:agent-preinstall-image-builder...
Getting image source signatures
Copying blob sha256:db5ac9e2b94214a23a3e7dd6a518358bc118d5304cbfba7e0250b7af1f3daf1d
Copying blob sha256:b5ddbc70c93efc07a634d09a4c598e797fca8fc7b9a13c225b3055b380b9fa70
Error: copying system image from manifest list: writing blob: adding layer with blob "sha256:b5ddbc70c93efc07a634d09a4c598e797fca8fc7b9a13c225b3055b380b9fa70"/""/"sha256:c79f3694349ffe3805aeff70f88a967e953efd3664e6804bbca71b72cdf3f5f1": unpacking failed (error: exit status 1; output: potentially insufficient UIDs or GIDs available in user namespace (requested 0:12 for /var/spool/mail): Check /etc/subuid and /etc/subgid if configured locally and run "podman system migrate": lchown /var/spool/mail: invalid argument)
Error: building at STEP "RUN --mount=type=secret,id=my_pull_secret,target=${PULL_SECRET_CONTAINER_PATH} hack/build-ove-image.sh --pull-secret-file "${PULL_SECRET_CONTAINER_PATH}" --ocp-version 4.20.0": while running runtime: exit status 125
```

When trying with `sudo podman build` it results in a problem accessing cdn-ubi.redhat.com
```
Errors during downloading metadata for repository 'ubi-9-baseos-rpms':
  - Curl error (28): Timeout was reached for https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/repodata/repomd.xml [Resolving timed out after 30000 milliseconds]
```