### PR TITLE
WIP AGENT-1258: Add buildah args to Konflux yaml files

### DIFF
--- a/.tekton/agent-installer-utils-pull-request.yaml
+++ b/.tekton/agent-installer-utils-pull-request.yaml
@@ -32,6 +32,13 @@ spec:
     value: Dockerfile
   - name: path-context
     value: tools/iso_builder
+  - name: build-args
+    value:
+      - "RELEASE_FLAG=--release-image-url"
+      - "RELEASE_VALUE=registry.ci.openshift.org/ocp/release:4.20.0-0.ci-2025-09-07-073945"
+      - "MAJOR_MINOR_VERSION=4.20"
+  - name: privileged-nested
+    value: 'true'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -208,20 +215,24 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PRIVILEGED_NESTED
-        value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_SECRET
+        value: "ove-ui-image-pull-secret"
+      - name: PLATFORM
+        value: "linux-root/amd64"
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:c9ef8d723f5c3d65ec910d6fdb74607332620289ab083d6c97c602226fe7a8d2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:252e5c94fb2375c43bdfd4b65097d246f4f37392956b08e5c38f366623a0b9ce
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/agent-installer-utils-push.yaml
+++ b/.tekton/agent-installer-utils-push.yaml
@@ -29,6 +29,11 @@ spec:
     value: Dockerfile
   - name: path-context
     value: tools/iso_builder
+  - name: build-args
+    value:
+      - "RELEASE_FLAG=--release-image-url"
+      - "RELEASE_VALUE=registry.ci.openshift.org/ocp/release:4.20.0-0.ci-2025-09-04-041923"
+      - "MAJOR_MINOR_VERSION=4.20"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
@@ -205,20 +210,26 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
-      - name: PRIVILEGED_NESTED
-        value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: ADDITIONAL_SECRET
+        value: "ove-ui-image-pull-secret"
+      - name: ADD_CAPABILITIES
+        value: "SYS_ADMIN,NET_ADMIN"
+      - name: PLATFORM
+        value: "linux-root/amd64"
+      - name: PRIVILEGED_NESTED
+        value: "true"
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah-oci-ta
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:c9ef8d723f5c3d65ec910d6fdb74607332620289ab083d6c97c602226fe7a8d2
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.4@sha256:252e5c94fb2375c43bdfd4b65097d246f4f37392956b08e5c38f366623a0b9ce
         - name: kind
           value: task
         resolver: bundles

--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -1,7 +1,22 @@
 # Use appliance image as the base
 FROM registry.ci.openshift.org/ocp/4.20:agent-preinstall-image-builder
+# TEST ONLY of podman run command
+# FROM quay.io/bfournie/openshift-appliance:latest
 
 USER root
+
+# TEST of running podman to see if cgroup write failure occurs
+# RUN podman run --privileged --cgroupns=host --network=none --rm alpine sh -c "mkdir -p /sys/fs/cgroup/test && echo 'hello' > /sys/fs/cgroup/test/file"
+RUN podman run --network=none --rm alpine:latest ls
+
+# Define the arguments that will be passed in from the pipeline
+ARG RELEASE_FLAG
+ARG RELEASE_VALUE
+ARG MAJOR_MINOR_VERSION
+# Set the environment variables using the values from the arguments
+ENV RELEASE_FLAG=${RELEASE_FLAG}
+ENV RELEASE_VALUE=${RELEASE_VALUE}
+ENV MAJOR_MINOR_VERSION=${MAJOR_MINOR_VERSION}
 
 # Copy the configuration script into the container
 COPY hack/build-ove-image.sh hack/helper.sh hack/logging.sh /tmp/
@@ -14,8 +29,8 @@ RUN chmod +x /tmp/logging.sh
 COPY ./config/${MAJOR_MINOR_VERSION}/. /
 
 # Run the configuration script to finish setting up appliance-config.yaml
-RUN --mount=type=secret,id=image_pull_secrets,target=/run/secrets/pull-secret.txt \
-    /tmp/build-ove-image.sh --pull-secret-file /run/secrets/pull-secret.txt "$RELEASE_FLAG" "$RELEASE_VALUE" \
+RUN --mount=type=secret,id=ove-ui-image-pull-secret/.dockerconfigjson \
+    /tmp/build-ove-image.sh --pull-secret-file /run/secrets/ove-ui-image-pull-secret/.dockerconfigjson "$RELEASE_FLAG" "$RELEASE_VALUE" \
     --dir / --step "configure"
 
 RUN dnf -y update; yum -y reinstall shadow-utils; \
@@ -23,9 +38,9 @@ yum -y install podman runc ; \
 rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Use runc as containers engine
-RUN mkdir -p /etc/containers/ && \
-  echo "[engine]" >> /etc/containers/containers.conf && \
-  echo "runtime=\"runc\"" >> /etc/containers/containers.conf
+# RUN mkdir -p /etc/containers/ && \
+#  echo "[engine]" >> /etc/containers/containers.conf && \
+#  echo "runtime=\"runc\"" >> /etc/containers/containers.conf
 
 # Run the openshift-appliance build live-iso command during the image build process.
 RUN /openshift-appliance build live-iso --log-level debug && rm -r /temp && rm -r /cache && rm -r /root/.oc-mirror
@@ -33,8 +48,8 @@ RUN /openshift-appliance build live-iso --log-level debug && rm -r /temp && rm -
 # Do the postprocessing step to generate the OVE ISO
 RUN dnf install -y xorriso rsync
 
-RUN --mount=type=secret,id=image_pull_secrets,target=/run/secrets/pull-secret.txt \
-    /tmp/build-ove-image.sh --pull-secret-file /run/secrets/pull-secret.txt $RELEASE_FLAG $RELEASE_VALUE --dir / --step "create-iso" \
+RUN --mount=type=secret,id=ove-ui-image-pull-secret/.dockerconfigjson \
+    /tmp/build-ove-image.sh --pull-secret-file /run/secrets/ove-ui-image-pull-secret/.dockerconfigjson $RELEASE_FLAG $RELEASE_VALUE --dir / --step "create-iso" \
     && rm /appliance.iso && rm -rf /isomnt
 
 # Override openshift-appliance entrypoint for testing purposes

--- a/tools/iso_builder/Makefile
+++ b/tools/iso_builder/Makefile
@@ -29,11 +29,11 @@ build-ove-iso:
 build-ove-iso-container:
 	# Build the container with specific capabilities to support podman used by openshift-appliance
 	@sudo buildah bud \
-		--env RELEASE_FLAG="$(RELEASE_FLAG)" \
-		--env RELEASE_VALUE="$(RELEASE_VALUE)" \
-		--env MAJOR_MINOR_VERSION="$(MAJOR_MINOR_VERSION)" \
+		--build-arg RELEASE_FLAG="$(RELEASE_FLAG)" \
+		--build-arg RELEASE_VALUE="$(RELEASE_VALUE)" \
+		--build-arg MAJOR_MINOR_VERSION="$(MAJOR_MINOR_VERSION)" \
 		--authfile $(PULL_SECRET_FILE) \
-		--secret id=image_pull_secrets,src=$(PULL_SECRET_FILE) \
+		--secret id=ove-ui-image-pull-secret/.dockerconfigjson,src=$(PULL_SECRET_FILE) \
 		--cap-add CAP_SYS_ADMIN \
 		--cap-add CAP_NET_ADMIN \
 		--storage-driver vfs \


### PR DESCRIPTION
Add the parameters needed to the Tekton files to build the OVE UI container image via the Dockerfile. The following buildah paramaters are added:
- args to define the OCP release to build (note that this is test only, eventually this will be input from another pipeline)
- secret from the stored secret for this Konflux component
- capabilities needed to run nested podman
- priviledge mode to run nested podman