### PR TITLE
AGENT-1302: Read template from .template path

### DIFF
--- a/tools/agent_tui/ui/rendezvous_ip_template.go
+++ b/tools/agent_tui/ui/rendezvous_ip_template.go
@@ -2,6 +2,9 @@ package ui
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"text/template"
 )
@@ -25,7 +28,10 @@ func (u *UI) saveRendezvousIPAddress(ipAddress string) error {
 }
 
 func templateRendezvousHostEnv(templateData interface{}) error {
-	data, err := os.ReadFile(RENDEZVOUS_HOST_ENV_PATH)
+	data, err := os.ReadFile(fmt.Sprintf("%s.template", RENDEZVOUS_HOST_ENV_PATH))
+	if errors.Is(err, fs.ErrNotExist) {
+		data, err = os.ReadFile(RENDEZVOUS_HOST_ENV_PATH)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Expect to read the rendezvous-host.env template from a separate .template file. The template is placed there by
openshift/installer#9941.

Only fall back to expecting the .env file to be a template if the former is not present. This change is backward-compatible.