### PR TITLE
AGENT-1302: Check for presence of registry instead of WorkflowType

### DIFF
--- a/tools/agent_tui/app.go
+++ b/tools/agent_tui/app.go
@@ -34,7 +34,6 @@ func App(app *tview.Application, rendezvousIP string, config checks.Config, chec
 	logger.Infof("Agent TUI git version: %s", version.Commit)
 	logger.Infof("Agent TUI build version: %s", version.Raw)
 	logger.Infof("Rendezvous IP: %s", rendezvousIP)
-	logger.Infof("Workflow Type: %s", config.WorkflowType)
 
 	var appUI *ui.UI
 	if app == nil {

--- a/tools/agent_tui/main/main.go
+++ b/tools/agent_tui/main/main.go
@@ -29,27 +29,24 @@ func main() {
 		logPath = "/tmp/agent_tui.log"
 		fmt.Printf("AGENT_TUI_LOG_PATH is unspecified, logging to: %v\n", logPath)
 	}
-	rendezvousIP, workflowType := getRendezvousHostEnv()
+	rendezvousIP := getRendezvousIP()
 	config := checks.Config{
 		ReleaseImageURL: releaseImage,
 		LogPath:         logPath,
-		WorkflowType:    workflowType,
 	}
 	agent_tui.App(nil, rendezvousIP, config)
 }
 
-// This function reads /etc/assisted/rendezvous-host.env
-// for NODE_ZERO_IP and WORKFLOY_TYPE.
-func getRendezvousHostEnv() (nodeZeroIP, workflowType string) {
+// getRendezvousIP reads NODE_ZERO_IP from /etc/assisted/rendezvous-host.env.
+func getRendezvousIP() (nodeZeroIP string) {
 	envMap, err := godotenv.Read(ui.RENDEZVOUS_HOST_ENV_PATH)
 	if err != nil {
-		return "", ""
+		return ""
 	}
 	nodeZeroIP = envMap["NODE_ZERO_IP"]
 	if nodeZeroIP == RENDEZVOUS_IP_TEMPLATE_VALUE {
 		nodeZeroIP = ""
 	}
-	workflowType = envMap["WORKFLOW_TYPE"]
 
-	return nodeZeroIP, workflowType
+	return nodeZeroIP
 }

--- a/tools/agent_tui/ui/check_page_test.go
+++ b/tools/agent_tui/ui/check_page_test.go
@@ -14,7 +14,6 @@ func TestCheckPageNavigation(t *testing.T) {
 	config := checks.Config{
 		ReleaseImageURL: "",
 		LogPath:         "/tmp/agent-tui.log",
-		WorkflowType:    "test",
 	}
 
 	logger := logrus.New()


### PR DESCRIPTION
We ultimately want to trigger behaviour based on what features are present (in this case, if there is a local registry then we don't need to check connectivity to the registry) rather than maintain a matrix of all the different modes and a distributed definition of what features are available in each.