### PR TITLE
OCPBUGS-61946: Include only final ISO in OVE UI container image

### DIFF
--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -1,5 +1,5 @@
 # Use appliance image as the base
-FROM registry.ci.openshift.org/ocp/4.20:agent-preinstall-image-builder
+FROM registry.ci.openshift.org/ocp/4.20:agent-preinstall-image-builder AS builder
 
 USER root
 
@@ -32,12 +32,11 @@ RUN /openshift-appliance build live-iso --log-level debug && rm -r /temp && rm -
 
 # Do the postprocessing step to generate the OVE ISO
 RUN dnf install -y xorriso rsync
-
 RUN --mount=type=secret,id=image_pull_secrets,target=/run/secrets/pull-secret.txt \
     /tmp/build-ove-image.sh --pull-secret-file /run/secrets/pull-secret.txt $RELEASE_FLAG $RELEASE_VALUE --dir / --step "create-iso" \
     && rm /appliance.iso && rm -rf /isomnt
 
-# Override openshift-appliance entrypoint for testing purposes
-ENTRYPOINT ["/bin/bash"]
+FROM scratch
 
-CMD ["/bin/bash", "-c", "sleep infinity"]
+# Copy final ISO as only thing from builder stage
+COPY --from=builder /agent-ove.$ARCH.iso /agent-ove.$ARCH.iso

--- a/tools/iso_builder/Makefile
+++ b/tools/iso_builder/Makefile
@@ -32,6 +32,7 @@ build-ove-iso-container:
 		--env RELEASE_FLAG="$(RELEASE_FLAG)" \
 		--env RELEASE_VALUE="$(RELEASE_VALUE)" \
 		--env MAJOR_MINOR_VERSION="$(MAJOR_MINOR_VERSION)" \
+		--env ARCH="$(ARCH)" \
 		--authfile $(PULL_SECRET_FILE) \
 		--secret id=image_pull_secrets,src=$(PULL_SECRET_FILE) \
 		--cap-add CAP_SYS_ADMIN \


### PR DESCRIPTION
Prevent the output from any earlier steps from being included in the container image created using Dockerfile.