### PR TITLE
OCPBUGS-61956: Disable Konflux go.mod PR updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "enabledManagers": ["tekton"]
+}


### PR DESCRIPTION
Disable the Konflux Renovate/MintMaker PR updates of go.mod dependencies.  Changes to files in .tekton will still receive PRs, for example for updates to Konflux tasks.

In addition the DependencyDashboard is enabled which will allow Renovate to show recommended dependency updates under Issues, but not actually create the PR.