### PR TITLE
AGENT-1203: Simplify build-ove-image.sh

### DIFF
--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -30,12 +30,6 @@ RUN mkdir -p /etc/containers/ && \
 # Run the openshift-appliance build live-iso command during the image build process.
 RUN /openshift-appliance build live-iso --log-level debug && rm -r /temp && rm -r /cache && rm -r /root/.oc-mirror
 
-# Do the postprocessing step to generate the OVE ISO
-RUN dnf install -y xorriso rsync
-RUN --mount=type=secret,id=image_pull_secrets,target=/run/secrets/pull-secret.txt \
-    /tmp/build-ove-image.sh --pull-secret-file /run/secrets/pull-secret.txt $RELEASE_FLAG $RELEASE_VALUE --dir / --step "create-iso" \
-    && rm /appliance.iso && rm -rf /isomnt
-
 FROM scratch
 
 # Copy final ISO as only thing from builder stage

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -70,85 +70,6 @@ function build_live_iso() {
     fi
 }
 
-function extract_live_iso() {
-    local appliance_mnt_dir="${appliance_work_dir}/isomnt"
-    if [ -d "${appliance_mnt_dir}" ]; then
-        echo "Skip extracting appliance ISO. Reusing ${appliance_mnt_dir}."
-    else
-        echo "Extracting ISO contents..."
-        mkdir -p "${appliance_mnt_dir}"
-
-        if [ ! -f "${appliance_work_dir}"/appliance.iso ]; then
-            echo "Error: Issue with appliance. The appliance.iso disk image file is missing."
-            echo "${appliance_work_dir}"
-            ls -lh "${appliance_work_dir}"
-            exit 1
-        fi
-        # Mount the ISO when not in a container
-        if [ ${appliance_work_dir} != '/' ]; then
-            $SUDO mount -o loop "${appliance_work_dir}"/appliance.iso "${appliance_mnt_dir}"
-        fi
-    fi
-    if [ -d "${work_dir}" ]; then
-        echo "Skip copying extracted appliance ISO contents to a writable directory. Reusing ${work_dir}."
-    else
-        mkdir -p "${work_dir}"
-        if [ ${appliance_work_dir} == '/' ]; then
-            # Use osirrox to extract the ISO without mounting it
-            $SUDO osirrox -indev "${appliance_work_dir}"/appliance.iso -extract / "${appliance_mnt_dir}"
-        fi
-        echo "Copying extracted appliance ISO contents to a writable directory."
-        $SUDO rsync -aH --info=progress2 "${appliance_mnt_dir}/" "${work_dir}/"
-        $SUDO chown -R $(whoami):$(whoami) "${work_dir}/"
-        if mountpoint -q ${appliance_mnt_dir}; then
-            $SUDO umount ${appliance_mnt_dir}
-        fi
-    fi
-    volume_label=$(xorriso -indev "${appliance_work_dir}"/appliance.iso -toc 2>/dev/null | awk -F',' '/ISO session/ {print $4}' | xargs)
-}
-
-function setup_agent_artifacts() {
-    local image=agent-installer-ui
-    local pull_spec=registry.ci.openshift.org/ocp/4.20:"${image}"
-    local image_dir="${work_dir}"/images/"${image}"
-
-    if [ ! -f "${image_dir}"/"${image}".tar ]; then
-        # Copy assisted-installer-ui image to /images dir
-        echo "skopeo copy UI image to oci-archive:${image_dir}/${image}.tar"
-        mkdir -p "${image_dir}"
-        skopeo copy -q --authfile="${PULL_SECRET_FILE}" docker://"${pull_spec}" oci-archive:"${image_dir}"/"${image}".tar
-    else
-        echo "Skip pulling assisted-installer-ui image. Reusing ${image_dir}/${image}.tar."
-    fi
-}
-
-function create_ove_iso() {
-    if [ ! -f "${agent_ove_iso}" ]; then
-        local boot_image=$work_dir/images/efiboot.img
-        if [ -f "${boot_image}" ]; then
-            local size=$(stat --format="%s" "${boot_image}")
-            # Calculate the number of 2048-byte sectors needed for the file
-            # Add 2047 to round up any remaining bytes to a full sector
-            local boot_load_size=$(( (size + 2047) / 2048 ))
-        else
-            echo "Error: Clean /tmp/iso_builder directory."
-            exit 1
-        fi
-
-        echo "Creating ${agent_ove_iso}."
-        xorriso -as mkisofs \
-        -o "${agent_ove_iso}" \
-        -J -R -V "${volume_label}" \
-        -b isolinux/isolinux.bin \
-        -c isolinux/boot.cat \
-        -no-emul-boot -boot-load-size 4 -boot-info-table \
-        -eltorito-alt-boot \
-        -e images/efiboot.img \
-        -no-emul-boot -boot-load-size "${boot_load_size}" \
-        "${work_dir}"
-    fi
-}
-
 function finalize()
 {
    if [ "${ARCH}" == "x86_64" ]; then
@@ -191,28 +112,13 @@ function build()
 
       create_appliance_config
       build_live_iso
-      extract_live_iso
-      setup_agent_artifacts
-      create_ove_iso
       finalize
       ;;
     "configure")
       create_appliance_config
       ;;
-    "create-iso")
-      extract_live_iso
-      setup_agent_artifacts
-      create_ove_iso
-      finalize
-
-      # Remove directory to limit size of container
-      rm -r ${work_dir}
-
-      # Move to top-level dir for easier retrieval
-      mv -v ${agent_ove_iso} ${appliance_work_dir}
-      ;;
   *)
-    echo "Error: The STEP variable must be 'all', 'configure', or 'create-iso'." >&2
+    echo "Error: The STEP variable must be 'all' or 'configure'." >&2
     exit 1
     ;;
 esac

--- a/tools/iso_builder/hack/helper.sh
+++ b/tools/iso_builder/hack/helper.sh
@@ -82,8 +82,8 @@ function validate_inputs() {
         STEP="all"
     fi
 
-    if [[ "$STEP" != "all" && "$STEP" != "configure" && "$STEP" != "create-iso" ]]; then
-        echo "Error: The STEP variable must be 'all', 'configure', or 'create-iso'." >&2
+    if [[ "$STEP" != "all" && "$STEP" != "configure" ]]; then
+        echo "Error: The STEP variable must be 'all' or 'configure'." >&2
         exit 1
     fi
 
@@ -153,7 +153,7 @@ function usage() {
     echo "  --arch <architecture>          Target CPU architecture (default: x86_64)"
     echo "  --ssh-key-file <path>          Path to the SSH key file (e.g., ~/.ssh/id_rsa)"
     echo "  --dir <path>                   Path for ISOBuilder assets (default: /tmp/iso_builder)"
-    echo "  --step <step>                  Control the steps that will be invoked, options are all, configure, and create-iso (default: all)"
+    echo "  --step <step>                  Control the steps that will be invoked, options are all and configure (default: all)"
     echo ""
     echo "Examples:"
     echo "$0 --pull-secret-file ~/pull_secret.json --release-image-url registry.ci.openshift.org/ocp/release:4.19.0-0.ci-2025-04-01-173804"


### PR DESCRIPTION
Remove old steps that were needed to included assisted-installer-ui.

The ui image is now retrieved from the release image.