### PR TITLE
Update OCP documentation links to latest versions

### DIFF
--- a/tools/iso_builder/README.md
+++ b/tools/iso_builder/README.md
@@ -23,7 +23,7 @@ By default:
 
 1. xorriso (see [xorriso](https://www.gnu.org/software/xorriso/) for more information). On CentOS, RHEL, run `sudo dnf install -y xorriso`
 2. isohybrid (see [isohybrid](https://man.archlinux.org/man/core/syslinux/isohybrid.1.en) for more information). On CentOS, RHEL, run `sudo dnf install -y syslinux`
-3. oc (see [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands) for more information).
+3. oc (see [oc](https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/cli_tools/openshift-cli-oc#cli-installing-cli_cli-developer-commands) for more information).
 4. podman (see [podman](https://podman.io/docs/installation) for more information).
 5. skopeo (see [skopeo](https://github.com/containers/skopeo/blob/main/install.md) for more information). On RHEL / CentOS Stream ≥ 8, run `sudo dnf -y install skopeo`
 


### PR DESCRIPTION
This PR updates OpenShift Container Platform documentation URLs to point to the latest available versions.

## Changes
- Automatically updated OCP documentation links using [ocp-doc-checker](https://github.com/sebrandon1/ocp-doc-checker)
- All documentation URLs now point to current versions

## Tool Information
This PR was created automatically by scanning the repository with `ocp-doc-checker`, which identifies and updates outdated OpenShift documentation links.

Repository: https://github.com/sebrandon1/ocp-doc-checker

---

**Tracking Issue:** https://github.com/sebrandon1/ocp-doc-checker/issues/18