### PR TITLE
OCPBUGS-65936: Update Konflux release version to 4.20.5

### DIFF
--- a/.tekton/ove-ui-iso-4-20-pull-request.yaml
+++ b/.tekton/ove-ui-iso-4-20-pull-request.yaml
@@ -40,11 +40,11 @@ spec:
   - name: privileged-nested
     value: 'true'
   - name: release-value
-    value: "quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64"
+    value: "quay.io/openshift-release-dev/ocp-release:4.20.5-x86_64"
   - name: major-minor-version
     value: "4.20"
   - name: patch-version
-    value: "4"
+    value: "5"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/ove-ui-iso-4-20-push.yaml
+++ b/.tekton/ove-ui-iso-4-20-push.yaml
@@ -37,11 +37,11 @@ spec:
   - name: privileged-nested
     value: 'true'
   - name: release-value
-    value: "quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64"
+    value: "quay.io/openshift-release-dev/ocp-release:4.20.5-x86_64"
   - name: major-minor-version
     value: "4.20"
   - name: patch-version
-    value: "4"
+    value: "5"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Updated the OCP release version in Konflux build configurations:
- release-value: quay.io/openshift-release-dev/ocp-release:4.20.5-x86_64
- patch-version: 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)