### PR TITLE
OCPBUGS-66431: Add Konflux PipelineRun params required by release pipeline

### DIFF
--- a/.tekton/ove-ui-iso-4-20-push.yaml
+++ b/.tekton/ove-ui-iso-4-20-push.yaml
@@ -42,6 +42,8 @@ spec:
     value: "4.20"
   - name: patch-version
     value: "6"
+  - name: build-source-image
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION
Set the` build-source-image=true `only for the push pipeline, i.e. on the PR merge. This will generate a .src image that will be used in the release pipeline` rh-sign-image` stage.