### PR TITLE
AGENT-1193: Add mirror-path and registry-cert support for OVE ISO builder

### DIFF
--- a/tools/iso_builder/Makefile
+++ b/tools/iso_builder/Makefile
@@ -4,6 +4,8 @@ ARCH ?= x86_64
 PULL_SECRET_FILE ?= ./pull-secret.json
 RELEASE_IMAGE_URL ?=
 RELEASE_IMAGE_VERSION ?=
+MIRROR_PATH ?=
+REGISTRY_CERT ?=
 
 ifdef RELEASE_IMAGE_VERSION
     RELEASE_FLAG := --ocp-version
@@ -25,7 +27,7 @@ clean-appliance-temp-dir:
 	hack/cleanup.sh clean-appliance-temp-dir
 	
 build-ove-iso:
-	hack/build-ove-image.sh $(RELEASE_FLAG) $(RELEASE_VALUE) --pull-secret-file $(PULL_SECRET_FILE)
+	hack/build-ove-image.sh $(RELEASE_FLAG) $(RELEASE_VALUE) --pull-secret-file "$(PULL_SECRET_FILE)" $(if $(MIRROR_PATH),--mirror-path "$(MIRROR_PATH)") $(if $(REGISTRY_CERT),--registry-cert "$(REGISTRY_CERT)")
 
 build-ove-iso-container:
 	# Build the container with specific capabilities to support skopeo used by openshift-appliance

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -13,12 +13,15 @@ export RELEASE_IMAGE_URL=""
 export ARCH=""
 export DIR_PATH=""
 export APPLIANCE_IMAGE=""
+export MIRROR_PATH=""
+export REGISTRY_CERT=""
 
 # Check user provided params
 [[ $# -lt 2 ]] && usage
 parse_inputs "$@"
 validate_inputs
 setup_vars
+
 
 function create_appliance_config() {
     # The appliance-config.yaml has been copied to the correct directory
@@ -54,6 +57,12 @@ sshKey: '$(cat "${SSH_KEY_FILE}")'
 EOF
         fi
 
+        if [[ -n "$MIRROR_PATH" ]]; then
+            cat << EOF >> ${cfg}
+mirrorPath: /mirror
+EOF
+        fi
+
     else
         echo "Skip creating appliance config. Reusing ${appliance_work_dir}/appliance-config.yaml"
     fi
@@ -61,9 +70,33 @@ EOF
 
 function build_live_iso() {
     if [ ! -f "${appliance_work_dir}"/appliance.iso ]; then
-       local appliance_image="${APPLIANCE_IMAGE:-registry.ci.openshift.org/ocp/${major_minor_version}:agent-preinstall-image-builder}"
+        local appliance_image="${APPLIANCE_IMAGE:-registry.ci.openshift.org/ocp/${major_minor_version}:agent-preinstall-image-builder}"
         echo "Building appliance ISO (image: ${appliance_image})"
-        $SUDO podman run --authfile "${PULL_SECRET_FILE}" --rm -it --privileged --pull always --net=host -v "${appliance_work_dir}"/:/assets:Z --env OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY "${appliance_image}" build live-iso --log-level debug
+
+        # Build the podman run command as an array to avoid shell injection
+        local -a podman_cmd=(${SUDO} podman run --authfile "${PULL_SECRET_FILE}" --rm -it --privileged --pull always --net=host -v "${appliance_work_dir}/:/assets:Z" --env OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY)
+        local -a appliance_cmd=(build live-iso --log-level debug)
+
+        # Add mirror path mount if provided
+        if [[ -n "${MIRROR_PATH}" ]]; then
+            echo "Using pre-mirrored images from: ${MIRROR_PATH}"
+            podman_cmd+=(-v "${MIRROR_PATH}:/mirror:Z")
+        fi
+
+        # Add registry certificate mount if provided (for custom registries with self-signed certs)
+        if [[ -n "${REGISTRY_CERT}" ]]; then
+            echo "Mounting registry certificate for TLS verification: ${REGISTRY_CERT}"
+            podman_cmd+=(-v "${REGISTRY_CERT}:/etc/pki/ca-trust/source/anchors/registry.crt:Z,ro")
+            # Override entrypoint to run update-ca-trust before openshift-appliance
+            # Use -ec to preserve the exit code of /openshift-appliance
+            # Workaround: Move appliance.iso to /assets if it was created in wrong location
+            podman_cmd+=(--entrypoint sh)
+            appliance_cmd=(-ec "update-ca-trust && /openshift-appliance --dir /assets ${appliance_cmd[*]} && if [ -f /appliance.iso ] && [ ! -f /assets/appliance.iso ]; then mv /appliance.iso /assets/appliance.iso; fi")
+        fi
+
+        set -x
+        "${podman_cmd[@]}" "${appliance_image}" "${appliance_cmd[@]}"
+        set +x
     else
         echo "Skip building appliance ISO. Reusing ${appliance_work_dir}/appliance.iso."
     fi

--- a/tools/iso_builder/hack/helper.sh
+++ b/tools/iso_builder/hack/helper.sh
@@ -6,14 +6,14 @@ set -euo pipefail
 function parse_inputs() {
     while [[ "$#" -gt 0 ]]; do
         case $1 in
-            --release-image-url) 
+            --release-image-url)
                 if [[ -n "$RELEASE_IMAGE_VERSION" ]]; then
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
                     usage
                     exit 1
                 fi
                 RELEASE_IMAGE_URL="$2"; shift ;;
-            --ocp-version) 
+            --ocp-version)
                 if [[ -n "$RELEASE_IMAGE_URL" ]]; then
                     echo "Error: Cannot specify both --release-image-url and --ocp-version." >&2
                     usage
@@ -24,9 +24,11 @@ function parse_inputs() {
             --pull-secret-file) PULL_SECRET_FILE="$2"; shift ;;
             --ssh-key-file) SSH_KEY_FILE="$2"; shift ;;
             --appliance-image) APPLIANCE_IMAGE="$2"; shift ;;
+            --mirror-path) [[ $# -lt 2 ]] && { echo "Error: --mirror-path requires a value." >&2; exit 1; }; MIRROR_PATH="$2"; shift ;;
+            --registry-cert) [[ $# -lt 2 ]] && { echo "Error: --registry-cert requires a value." >&2; exit 1; }; REGISTRY_CERT="$2"; shift ;;
             --dir) DIR_PATH="$2"; shift ;;
             --step) STEP="$2"; shift ;;
-            *) 
+            *)
                 echo "Unknown parameter: $1" >&2
                 usage
                 exit 1 ;;
@@ -68,6 +70,16 @@ function validate_inputs() {
     fi
     if [[ -n "$SSH_KEY_FILE" && ! -f "$SSH_KEY_FILE" ]]; then
         echo "File $SSH_KEY_FILE does not exist." >&2
+        exit 1
+    fi
+
+    if [[ -n "$REGISTRY_CERT" && ! -f "$REGISTRY_CERT" ]]; then
+        echo "Error: Registry certificate file $REGISTRY_CERT does not exist." >&2
+        exit 1
+    fi
+
+    if [[ -n "$MIRROR_PATH" && ! -d "$MIRROR_PATH" ]]; then
+        echo "Error: Mirror path $MIRROR_PATH does not exist or is not a directory." >&2
         exit 1
     fi
 
@@ -156,6 +168,8 @@ function usage() {
     echo "  --arch <architecture>          Target CPU architecture (default: x86_64)"
     echo "  --ssh-key-file <path>          Path to the SSH key file (e.g., ~/.ssh/id_rsa)"
     echo "  --dir <path>                   Path for ISOBuilder assets (default: /tmp/iso_builder)"
+    echo "  --mirror-path <path>           Path to pre-mirrored images (skips oc-mirror if provided)"
+    echo "  --registry-cert <path>         Path to registry certificate for custom registries with self-signed certs"
     echo "  --step <step>                  Control the steps that will be invoked, options are all, configure, and create-iso (default: all)"
     echo ""
     echo "Examples:"


### PR DESCRIPTION
Add support for using pre-mirrored images (--mirror-path) and custom
registry certificates (--registry-cert) when building OVE ISOs. This
allows building ISOs in disconnected environments without requiring
oc-mirror to run during the build process.

Note: mirror-path and registry-cert options are only available when
using the script build method (build-ove-iso). The container build
method (build-ove-iso-container) does not support these options.

Changes to hack/build-ove-image.sh:
- Add --mirror-path parameter to pass pre-mirrored images directory
- Add --registry-cert parameter for custom registry certificates
- Mount mirror path and certificate when running appliance container
- Override entrypoint to install certificate before running appliance

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for optional mirror paths and registry certificates when building OVE ISOs, enabling offline image mirroring and custom certificate handling.
* **Bug Fixes / Reliability**
  * Build process now conditionally includes mounts and certificate handling only when provided, improving robustness.
* **Documentation**
  * CLI usage updated and input validation added for the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->