### PR TITLE
AGENT-1476: Configure CI integration and add Prow e2e test to Konflux

### DIFF
--- a/.tekton/ove-ui-iso-prow-job-4.21.yaml
+++ b/.tekton/ove-ui-iso-prow-job-4.21.yaml
@@ -1,0 +1,73 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: abi-ove-konflux-prow-integration
+spec:
+  description: >-
+    Run Prow jobs for testing the ove-ui-iso-4-21 konflux component.
+  params:
+    - name: GANGWAY_TOKEN
+      type: string
+      description: Token to authenticate with gangway
+      default: gangway-token
+    - description: 'Snapshot of the application'
+      name: SNAPSHOT
+      default: '{"components": [{"name":"ove-ui-iso-4-21", "containerImage": "http://quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso-4-21:latest"}]}'
+      type: string
+  tasks:
+    - name: get-catalog-image
+      params:
+      - name: SNAPSHOT
+        value: $(params.SNAPSHOT)
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+        results:
+          - name: CATALOG_IMAGE
+            description: "The catalog image extracted from the SNAPSHOT"
+        steps:
+          - name: get-catalog-image
+            image: registry.redhat.io/openshift4/ose-cli:latest
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+            script: |
+              #!/bin/bash
+              set -e
+              dnf -y install jq
+              echo "Snapshot: ${SNAPSHOT}"
+              catalogImage=$(jq -r '.components[] | select(.name=="ove-ui-iso-4-21") | .containerImage' <<< "${SNAPSHOT}")
+              echo "Catalog image: ${catalogImage}"
+              echo -n "${catalogImage}" > $(results.CATALOG_IMAGE.path)
+    - name: prowjob-ove421
+      displayName: "Running prow job $(params.PROWJOB_NAME)"
+      timeout: "5h"
+      runAfter:
+        - get-catalog-image
+      taskRef:
+        resolver: git
+        params:
+        - name: url
+          value: https://github.com/openshift/konflux-tasks
+        - name: revision
+          value: main
+        - name: pathInRepo
+          value: tasks/provide-prowjob/0.1/provide-prowjob.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: PROWJOB_ORG
+          value: 'openshift-eng'
+        - name: PROWJOB_REPO
+          value: 'agent-qe-infra'
+        - name: VARIANT
+          value: 'amd64-nightly'
+        - name: ARTIFACTS_BUILD_ROOT
+          value: quay-proxy.ci.openshift.org/openshift/ci:openshift_release_rhel-9-release-golang-1.23-openshift-4.21
+        - name: ENVS
+          value: 'SNAPSHOT=$(tasks.get-catalog-image.results.CATALOG_IMAGE)'
+      matrix:
+        params:
+          - name: PROWJOB_NAME
+            value:
+              - periodic-ci-openshift-eng-agent-qe-infra-release-4.21-amd64-nightly-baremetal-ove-compact-disc-konflux


### PR DESCRIPTION
This code allows Prow CI jobs to be triggered from Konflux via Gangway API

Task name: `prowjob-ove421`
Prow CI job name: `periodic-ci-openshift-eng-agent-qe-infra-release-4.21-amd64-nightly-baremetal-ove-compact-disc-konflux` added here https://github.com/openshift/release/pull/77291 

Requirements:

- Obtain the Gangway token with `oc -n "konflux-tp" extract "secret/api-token-secret-2025-04" --to=- --keys=token`

- Add the Gangway token as secret in Konflux, with name `gangway-token` and under the key `token` add the value of the secret


**_Update integration test URL on konflux after merge_**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Tekton Task that triggers a prow job, returns its execution ID and URL, and reports final status.
  * Configurable triggering with snapshot/image overrides, optional injected environment variables, and retry/delay controls.
  * Added a Pipeline to discover the catalog image and run the new Task with parameterized job names and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->