### PR TITLE
OCPBUGS-77250: Use mtv-operator from 4.20 catalog

### DIFF
--- a/tools/iso_builder/config/4.21/appliance-config.yaml
+++ b/tools/iso_builder/config/4.21/appliance-config.yaml
@@ -16,9 +16,6 @@ operators:
       - name: kubevirt-hyperconverged
         channels:
           - name: stable
-      - name: mtv-operator
-        channels:
-          - name: release-v2.8
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable
@@ -55,3 +52,8 @@ operators:
       - name: cluster-logging
         channels:
           - name: stable-6.4
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.20
+    packages:
+      - name: mtv-operator
+        channels:
+          - name: release-v2.10


### PR DESCRIPTION
It turns out that mtv-operator.v2.11.0 is not valid and results in an error when its used:
`FATAL 2026/02/24 21:08:51  [ERROR]  : [Executor] collection error: collect catalog "registry.redhat.io/redhat/redhat-operator-index:v4.21": error parsing image : unknown image : reference name is empty`

Changed to use the release-v2.10 of mtv-operator from the v4.20 catalog for now. Once the operator in the v4.20 catalog is valid this will be updated.