### PR TITLE
NO-JIRA: Pass environment through to podman

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -92,7 +92,7 @@ function build()
     if [ "$(id -u)" -eq 0 ]; then
         SUDO=""
     else
-        SUDO="sudo"
+        SUDO="sudo -E"
     fi
 
     case "$STEP" in


### PR DESCRIPTION
For users not running as root, sudo would prevent the dev-scripts we need to pass the dev-scripts environment to podman, which would prevent OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY having any effect.