### PR TITLE
OCPBUGS-81585: Update operator versions

### DIFF
--- a/tools/iso_builder/config/4.21/appliance-config.yaml
+++ b/tools/iso_builder/config/4.21/appliance-config.yaml
@@ -50,7 +50,7 @@ operators:
           - name: "4.21"
       - name: loki-operator
         channels:
-          - name: stable-6.4
+          - name: stable-6.5
       - name: cluster-logging
         channels:
-          - name: stable-6.4
+          - name: stable-6.5

--- a/tools/iso_builder/config/4.22/appliance-config.yaml
+++ b/tools/iso_builder/config/4.22/appliance-config.yaml
@@ -51,7 +51,7 @@ operators:
           - name: "4.21"
       - name: loki-operator
         channels:
-          - name: stable-6.4
+          - name: stable-6.5
       - name: cluster-logging
         channels:
-          - name: stable-6.4
+          - name: stable-6.5


### PR DESCRIPTION
The cluster-logging and loki-operators have been updated to stable-6.5 in the catalog and the config must be updated.