### PR TITLE
NO-JIRA: enable xtrace in build-ove-image.sh for debugging

### DIFF
--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Fail on unset variables and errors 
-set -euo pipefail
+set -xeuo pipefail
 
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPTDIR/helper.sh


### PR DESCRIPTION
Failures inside the script are hidden without xtrace. With xtrace enabled, the output shows exactly which command failed. For example:

+(build_ove_iso_script:1): echo 'Start building Agent OVE ISO' Start building Agent OVE ISO
+(build_ove_iso_script:2): ./hack/build-ove-image.sh \
  --pull-secret-file /path/to/pull_secret.json \
  --release-image-url registry.example.com/release@sha256:... \
  --ssh-key-file ~/.ssh/id_rsa.pub \
  --dir /path/to/iso_builder
make: *** [Makefile:29: agent_create_cluster] Error 1

The internal error is not shown.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>