### PR TITLE
OCPBUGS-83860: Set DISABLE_IMAGE_POLICY in Konflux Dockerfile

### DIFF
--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -8,6 +8,9 @@ ARG MAJOR_MINOR_VERSION
 ARG PATCH_VERSION
 ARG ARCH
 
+# Set environment variable for image policy
+ENV OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY=true
+
 # Copy the configuration script into the container
 COPY hack/build-ove-image.sh hack/helper.sh /tmp/
 RUN chmod +x /tmp/build-ove-image.sh


### PR DESCRIPTION
Set the OPENSHIFT_INSTALL_EXPERIMENTAL_DISABLE_IMAGE_POLICY envirorment variable so that it is passed down to the appliance for building OVE images.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ISO builder container image configuration with additional environment variable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->