### PR TITLE
OCPBUGS-85484: Update appliance config to use lvm-operator

### DIFF
--- a/tools/iso_builder/config/4.23/appliance-config.yaml
+++ b/tools/iso_builder/config/4.23/appliance-config.yaml
@@ -43,9 +43,9 @@ operators:
       - name: redhat-oadp-operator
         channels:
           - name: stable
-      - name: local-storage-operator
+      - name: lvms-operator
         channels:
-          - name: stable
+          - name: stable-4.21
       - name: numaresources-operator
         channels:
           - name: "4.21"

--- a/tools/iso_builder/config/5.0/appliance-config.yaml
+++ b/tools/iso_builder/config/5.0/appliance-config.yaml
@@ -43,9 +43,9 @@ operators:
       - name: redhat-oadp-operator
         channels:
           - name: stable
-      - name: local-storage-operator
+      - name: lvms-operator
         channels:
-          - name: stable
+          - name: stable-4.21
       - name: numaresources-operator
         channels:
           - name: "4.21"


### PR DESCRIPTION
The lvm-operator is being included as a dependency for CNV, instead of lso-operator. This change updates the appliance-config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated operator configurations in appliance builds for versions 4.23 and 5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->