### PR TITLE
OCPBUGS-86036: Filter out link-local IPv6 addresses

### DIFF
--- a/tools/agent_tui/ui/rendezvous_ip_select.go
+++ b/tools/agent_tui/ui/rendezvous_ip_select.go
@@ -66,7 +66,7 @@ func (u *UI) hostIPAddresses() []string {
 		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
 			if ipnet.IP.To4() != nil && !ipnet.IP.IsLinkLocalUnicast() {
 				ipv4 = append(ipv4, ipnet.IP.String())
-			} else if ipnet.IP.To16() != nil {
+			} else if ipnet.IP.To16() != nil && !ipnet.IP.IsLinkLocalUnicast() {
 				ipv6 = append(ipv6, ipnet.IP.String())
 			}
 		}


### PR DESCRIPTION
Filter out link-local IPv6 addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * IPv6 address filtering now excludes link-local unicast addresses from the IP selection interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->