### PR TITLE
AGENT-1536, OCPBUGS-89233: bump mtv-operator channel to release-v2.12

### DIFF
--- a/tools/iso_builder/config/4.21/appliance-config.yaml
+++ b/tools/iso_builder/config/4.21/appliance-config.yaml
@@ -17,7 +17,7 @@ operators:
           - name: stable
       - name: mtv-operator
         channels:
-          - name: release-v2.11
+          - name: release-v2.12
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable

--- a/tools/iso_builder/config/4.22/appliance-config.yaml
+++ b/tools/iso_builder/config/4.22/appliance-config.yaml
@@ -18,7 +18,7 @@ operators:
           - name: stable
       - name: mtv-operator
         channels:
-          - name: release-v2.11
+          - name: release-v2.12
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable

--- a/tools/iso_builder/config/4.23/appliance-config.yaml
+++ b/tools/iso_builder/config/4.23/appliance-config.yaml
@@ -18,7 +18,7 @@ operators:
           - name: stable
       - name: mtv-operator
         channels:
-          - name: release-v2.11
+          - name: release-v2.12
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable

--- a/tools/iso_builder/config/5.0/appliance-config.yaml
+++ b/tools/iso_builder/config/5.0/appliance-config.yaml
@@ -18,7 +18,7 @@ operators:
           - name: stable
       - name: mtv-operator
         channels:
-          - name: release-v2.11
+          - name: release-v2.12
       - name: kubernetes-nmstate-operator
         channels:
           - name: stable


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated operator package channel selection to `release-v2.12` (from `release-v2.11`) across the supported appliance configuration versions, including `mtv-operator` and `kubevirt-hyperconverged`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->