### PR TITLE
AGENT-1552: Add lvms-operator to config

### DIFF
--- a/tools/iso_builder/config/4.23/appliance-config.yaml
+++ b/tools/iso_builder/config/4.23/appliance-config.yaml
@@ -46,6 +46,9 @@ operators:
       - name: local-storage-operator
         channels:
           - name: stable
+      - name: lvms-operator
+        channels:
+          - name: stable-4.21
       - name: numaresources-operator
         channels:
           - name: "4.21"

--- a/tools/iso_builder/config/5.0/appliance-config.yaml
+++ b/tools/iso_builder/config/5.0/appliance-config.yaml
@@ -46,6 +46,9 @@ operators:
       - name: local-storage-operator
         channels:
           - name: stable
+      - name: lvms-operator
+        channels:
+          - name: stable-4.21
       - name: numaresources-operator
         channels:
           - name: "4.21"


### PR DESCRIPTION
Include lvms-operator in the list of included operator images. Now that storage operators are removed as CNV dependencies in https://github.com/openshift/assisted-service/pull/10541 including the images allows them to be optionally included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an additional operator package entry to the appliance configuration.
  * Enabled the `lvms-operator` to be included and configured to follow the `stable-4.21` channel.
  * This applies to both the 5.0 and 4.23 appliance configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->