### PR TITLE
OCPBUGS-98101: Use build platform with more disk space

### DIFF
--- a/.tekton/ove-ui-iso-pull-request.yaml
+++ b/.tekton/ove-ui-iso-pull-request.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: ocp-agent-based-installer-tenant
 spec:
   timeouts:
-    pipeline: 4h
+    pipeline: 5h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -30,7 +30,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-root/amd64
+    - linux-d320-m8xlarge/amd64
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -38,11 +38,11 @@ spec:
   - name: privileged-nested
     value: 'true'
   - name: release-value
-    value: "quay.io/openshift-release-dev/ocp-release:4.21.10-x86_64"
+    value: "quay.io/openshift-release-dev/ocp-release:4.22.4-x86_64"
   - name: major-minor-version
-    value: "4.21"
+    value: "4.22"
   - name: patch-version
-    value: "10"
+    value: "4"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
@@ -261,7 +261,7 @@ spec:
         value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
-      timeout: 3h
+      timeout: 5h
       taskRef:
         params:
         - name: name

--- a/.tekton/ove-ui-iso-push.yaml
+++ b/.tekton/ove-ui-iso-push.yaml
@@ -17,7 +17,7 @@ metadata:
   namespace: ocp-agent-based-installer-tenant
 spec:
   timeouts:
-    pipeline: 4h
+    pipeline: 5h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -27,7 +27,7 @@ spec:
     value: quay.io/redhat-user-workloads/ocp-agent-based-installer-tenant/ove-ui-iso:{{revision}}
   - name: build-platforms
     value:
-    - linux-root/amd64
+    - linux-d320-m8xlarge/amd64
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -35,11 +35,11 @@ spec:
   - name: privileged-nested
     value: 'true'
   - name: release-value
-    value: "quay.io/openshift-release-dev/ocp-release:4.21.10-x86_64"
+    value: "quay.io/openshift-release-dev/ocp-release:4.22.4-x86_64"
   - name: major-minor-version
-    value: "4.21"
+    value: "4.22"
   - name: patch-version
-    value: "10"
+    value: "4"
   pipelineSpec:
     description: |
       This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline settings for both pull request and push workflows, including switching the build platform from `linux-root/amd64` to `linux-d320-m8xlarge/amd64` and increasing the pipeline timeout from **4h** to **5h**.
  * Increased the pull request pipeline execution timeout and adjusted a later task timeout from **3h** to **5h**.
  * Bumped OCP release parameters to target **4.22.4** (major/minor/patch components) for both workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->