### PR TITLE
OCPBUGS-98743: Update cluster-logging and loki operator versions

### DIFF
--- a/tools/iso_builder/config/4.21/appliance-config.yaml
+++ b/tools/iso_builder/config/4.21/appliance-config.yaml
@@ -50,7 +50,7 @@ operators:
           - name: "4.21"
       - name: loki-operator
         channels:
-          - name: stable-6.5
+          - name: stable-6.6
       - name: cluster-logging
         channels:
-          - name: stable-6.5
+          - name: stable-6.6

--- a/tools/iso_builder/config/4.22/appliance-config.yaml
+++ b/tools/iso_builder/config/4.22/appliance-config.yaml
@@ -51,7 +51,7 @@ operators:
           - name: "4.21"
       - name: loki-operator
         channels:
-          - name: stable-6.5
+          - name: stable-6.6
       - name: cluster-logging
         channels:
-          - name: stable-6.5
+          - name: stable-6.6


### PR DESCRIPTION
This is a manual backport of https://github.com/openshift/agent-installer-utils/pull/315

The versions in appliance-config needs updating:
```
$ oc-mirror --v1 list operators --catalog registry.redhat.io/redhat/redhat-operator-index:v4.21 | grep -E "cluster-logging|loki" W0715 00:03:56.817659  959945 mirror.go:84] ⚠️  oc-mirror v1 is deprecated (started in 4.18 release) and will be removed in a future release - please migrate to oc-mirror --v2
cluster-logging                                               stable-6.6
loki-operator                                                 stable-6.6
```