### PR TITLE
OCPBUGS-98628: Increase resources for syft

### DIFF
--- a/.tekton/ove-ui-iso-4-21-push.yaml
+++ b/.tekton/ove-ui-iso-4-21-push.yaml
@@ -558,4 +558,10 @@ spec:
           memory: 8Gi      # Request 8GB or more as needed
         limits:
           memory: 8Gi
+    - name: sbom-syft-generate
+      computeResources:
+        requests:
+          memory: 16Gi  # Increase this specifically for syft
+        limits:
+          memory: 16Gi
 status: {}


### PR DESCRIPTION
The STEP-SBOM-SYFT-GENERATE never completes when running the on-push. Increasing the resources.