### PR TITLE
OCPBUGS-98628: Increase time for Konflux on-push job

### DIFF
--- a/.tekton/ove-ui-iso-4-21-push.yaml
+++ b/.tekton/ove-ui-iso-4-21-push.yaml
@@ -249,7 +249,7 @@ spec:
         value: $(params.buildah-format)
       runAfter:
       - prefetch-dependencies
-      timeout: 3h
+      timeout: 5h
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
The time limit was increased for the pull but not for the push, making them consistent.