### PR TITLE
OCPBUGS-99745: Use Operator catalog in 4.22 for OVE

### DIFF
--- a/tools/iso_builder/config/4.22/appliance-config.yaml
+++ b/tools/iso_builder/config/4.22/appliance-config.yaml
@@ -11,7 +11,7 @@ imageRegistry:
 additionalImages:
   - name: registry.redhat.io/rhel9/support-tools:latest
 operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.21
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.22
     packages:
       - name: kubevirt-hyperconverged
         channels:
@@ -24,13 +24,13 @@ operators:
           - name: stable
       - name: node-healthcheck-operator
         channels:
-          - name: stable          
+          - name: stable
       - name: node-maintenance-operator
         channels:
           - name: stable
       - name: fence-agents-remediation
         channels:
-          - name: stable          
+          - name: stable
       - name: cluster-kube-descheduler-operator
         channels:
           - name: stable
@@ -46,9 +46,12 @@ operators:
       - name: local-storage-operator
         channels:
           - name: stable
+      - name: lvms-operator
+        channels:
+          - name: stable-4.22
       - name: numaresources-operator
         channels:
-          - name: "4.21"
+          - name: "4.22"
       - name: loki-operator
         channels:
           - name: stable-6.6

--- a/tools/iso_builder/config/4.23/appliance-config.yaml
+++ b/tools/iso_builder/config/4.23/appliance-config.yaml
@@ -11,7 +11,7 @@ imageRegistry:
 additionalImages:
   - name: registry.redhat.io/rhel9/support-tools:latest
 operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.21
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.22
     packages:
       - name: kubevirt-hyperconverged
         channels:
@@ -48,10 +48,10 @@ operators:
           - name: stable
       - name: lvms-operator
         channels:
-          - name: stable-4.21
+          - name: stable-4.22
       - name: numaresources-operator
         channels:
-          - name: "4.21"
+          - name: "4.22"
       - name: loki-operator
         channels:
           - name: stable-6.6

--- a/tools/iso_builder/config/5.0/appliance-config.yaml
+++ b/tools/iso_builder/config/5.0/appliance-config.yaml
@@ -11,7 +11,7 @@ imageRegistry:
 additionalImages:
   - name: registry.redhat.io/rhel9/support-tools:latest
 operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.21
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.22
     packages:
       - name: kubevirt-hyperconverged
         channels:
@@ -48,10 +48,10 @@ operators:
           - name: stable
       - name: lvms-operator
         channels:
-          - name: stable-4.21
+          - name: stable-4.22
       - name: numaresources-operator
         channels:
-          - name: "4.21"
+          - name: "4.22"
       - name: loki-operator
         channels:
           - name: stable-6.6


### PR DESCRIPTION
Now that all the necessary operators are available in the 4.22 catalog this should be used for OVE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Updated appliance builds to use the OpenShift 4.22 operator catalog.
  - Aligned LVM Storage and NUMA Resources operator channels with version 4.22 across supported appliance releases.
  - Added Node Maintenance and Fence Agents Remediation operators to the 4.22 configuration.
  - Added the LVM Storage operator with its stable 4.22 channel where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->