### PR TITLE
AGENT-1568: Add lvms-operator to config

### DIFF
--- a/.tekton/ove-ui-iso-4-22-pull-request.yaml
+++ b/.tekton/ove-ui-iso-4-22-pull-request.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: ocp-agent-based-installer-tenant
 spec:
   timeouts:
-    pipeline: 4h
+    pipeline: 5h
   params:
   - name: git-url
     value: '{{source_url}}'
@@ -30,7 +30,7 @@ spec:
     value: 5d
   - name: build-platforms
     value:
-    - linux-root/amd64
+    - linux-d320-m8xlarge/amd64
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -261,7 +261,7 @@ spec:
         value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
-      timeout: 3h
+      timeout: 5h
       taskRef:
         params:
         - name: name
@@ -553,6 +553,14 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: workspace
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 50Gi  # Increase this to fit the ISO
   taskRunSpecs:
   - pipelineTaskName: build-images
     stepSpecs:

--- a/tools/iso_builder/config/4.22/appliance-config.yaml
+++ b/tools/iso_builder/config/4.22/appliance-config.yaml
@@ -46,6 +46,9 @@ operators:
       - name: local-storage-operator
         channels:
           - name: stable
+      - name: lvms-operator
+        channels:
+          - name: stable-4.21
       - name: numaresources-operator
         channels:
           - name: "4.21"


### PR DESCRIPTION
This is a backport of https://github.com/openshift/agent-installer-utils/pull/311.

Note that the .texton files are also updated to use the the large VM platform in order to build the ISO. We have this same change in master and in 4.21, and it needed to be updated here to get a successful build.