### PR TITLE
AGENT-1577: Use master branch of appliance as image builder

### DIFF
--- a/tools/iso_builder/CLAUDE.md
+++ b/tools/iso_builder/CLAUDE.md
@@ -94,7 +94,7 @@ The build follows these steps:
      - SSH key (optional)
 
 4. **ISO Build** (`build_live_iso()`)
-   - Uses appliance image: `quay-proxy.ci.openshift.org/openshift/ci:ocp_<major.minor>_agent-preinstall-image-builder`
+   - Uses appliance image: `quay-proxy.ci.openshift.org/openshift/ci:ocp_<major.minor>_agent-release-iso-builder`
    - Runs podman with privileged mode and host networking
    - Mounts appliance work dir to `/assets` in container
    - Executes: `build live-iso --log-level debug`

--- a/tools/iso_builder/Dockerfile
+++ b/tools/iso_builder/Dockerfile
@@ -1,5 +1,5 @@
 ARG MAJOR_MINOR_VERSION
-FROM quay-proxy.ci.openshift.org/openshift/ci:ocp_${MAJOR_MINOR_VERSION}_agent-preinstall-image-builder AS builder
+FROM quay-proxy.ci.openshift.org/openshift/ci:ocp_${MAJOR_MINOR_VERSION}_agent-release-iso-builder AS builder
 
 # Define the arguments that will be passed in from the pipeline
 ARG RELEASE_FLAG

--- a/tools/iso_builder/hack/build-ove-image.sh
+++ b/tools/iso_builder/hack/build-ove-image.sh
@@ -70,7 +70,7 @@ EOF
 
 function build_live_iso() {
     if [ ! -f "${appliance_work_dir}"/appliance.iso ]; then
-        local appliance_image="${APPLIANCE_IMAGE:-quay-proxy.ci.openshift.org/openshift/ci:ocp_${major_minor_version}_agent-preinstall-image-builder}"
+        local appliance_image="${APPLIANCE_IMAGE:-quay-proxy.ci.openshift.org/openshift/ci:ocp_${major_minor_version}_agent-release-iso-builder}"
         echo "Building appliance ISO (image: ${appliance_image})"
 
         # Build the podman run command as an array to avoid shell injection


### PR DESCRIPTION
Switch to the agent-release-iso-builder CI image that is built from the current OCP release branch.

This replaces agent-preinstall-image-builder, which is now built from the branch of the same name and does not use stable branches.

This depends on https://github.com/openshift/release/pull/83022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ISO construction to use the latest release ISO builder image.
  * Updated the live ISO creation workflow to reference the new builder image.
  * Revised related documentation to reflect the updated image name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->